### PR TITLE
crontabs: stop killing dnsmasq

### DIFF
--- a/roles/cfg_openwrt/files/corerouter/crontabs/root
+++ b/roles/cfg_openwrt/files/corerouter/crontabs/root
@@ -1,3 +1,2 @@
 18 * * * *	test -e /usr/sbin/owm.lua && /usr/sbin/owm.lua
-*/5 * * * *	killall -HUP dnsmasq
 */10 * * * *    /etc/config/airmax_dfs_reset


### PR DESCRIPTION
Why should we periodically kill dnsmasq? Stop doing that.