### PR TITLE
added missing netaddr requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ansible >= 2.8
 ansible_merge_vars >= 5.0.0
 jmespath >= 0.10.0
+netaddr >= 0.8.0


### PR DESCRIPTION
netaddr is required for generating some of the configurations