### PR TITLE
common: include contact data

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,15 @@ When defining a new location, you need to create a directory named like `locatio
 
 ##### general.yml
 
-This file might be fairly self-explanatory. Please mind that a contact is mandatory. If you don't like to give your email address, you can use the link to the contact form, that you've got from [config.berlin.freifunk.net](https://config.berlin.freifunk.net)
+This file might be fairly self-explanatory. Please mind that a contact is mandatory. _If you don't like to give your email address, you can use the link to the contact form, that you've got from [config.berlin.freifunk.net](https://config.berlin.freifunk.net)_.
 
 ```yml
 ---
-contact_nickname: 'Petrosilius Quaccus'
+contact_name: 'Petrosilius Quaccus'
+contact_nickname: 'Petro'
 contact_email: 'quaccus@example.com'
+# or:
+contact_email: 'https://config.berlin.freifunk.net/contact/446x/ImZmZnctZV0LTA0Ig.FFbQ8w._ZCA4hFY3zR8MdDVNrv3okqwPU'
 ```
 
 ##### owm.yml

--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -2,8 +2,8 @@
 zonename: 'Europe/Berlin'
 timezone: 'CET-1CEST,M3.5.0,M10.5.0/3'
 
-contact_nickname: 'your_friendly_freifunk_operator'
-contact_email: 'no@mail.de'
+contact_nickname: 'please_add_operator_name'
+contact_email: 'please_add_operators_contact'
 
 
 dns_servers:

--- a/roles/cfg_openwrt/templates/common/config/freifunk.j2
+++ b/roles/cfg_openwrt/templates/common/config/freifunk.j2
@@ -1,5 +1,10 @@
 config public 'contact'
+{% if contact_name is defined %}
+	option name '{{ contact_name }}'
+{% endif %}
+{% if contact_name is not defined or contact_nickname != 'please_add_operator_name' %}
 	option nickname '{{ contact_nickname }}'
+{% endif %}
 	option mail '{{ contact_email }}'
 	option location '{{ location_nice }}'
 


### PR DESCRIPTION
Even if provided, contact data wasn't written into the configuration.
This fixes it.

Signed-off-by: Martin Hübner <martin.hubner@web.de>