### PR TITLE
uplink_gateway: switch to NOTRACK

### DIFF
--- a/roles/cfg_openwrt/templates/uplink_gateway/conntrackd/conntrackd.conf.j2
+++ b/roles/cfg_openwrt/templates/uplink_gateway/conntrackd/conntrackd.conf.j2
@@ -1,5 +1,5 @@
 Sync {
-    Mode FTFW {
+    Mode NOTRACK {
         DisableExternalCache On
         StartupResync on
     }


### PR DESCRIPTION
FTFW:
This mode is based on a reliable protocol that performs message
tracking. Thus, the protocol can recover from message loss, re-ordering
and corruption.

NOTRACK
Is the most simple mode as it is based on a best effort replication
protocol, ie. unreliable protocol. This protocol sends and receives
the state information without performing any specific checking.

Source: https://manpages.debian.org/testing/conntrackd/conntrackd.conf.5.en.html

We use samplicator with UDP so we should switch to NOTRACK.

Fixes: #96 (uplink_gateways: conntrackd goes bad)