### PR TITLE
uplink: add ipv6 prefix to lo and redistribute

### DIFF
--- a/host_vars/l105-gw/gateway.yml
+++ b/host_vars/l105-gw/gateway.yml
@@ -9,6 +9,8 @@
 # Disable noping as we use dhcp and static assignments
 # both in mgmt network
 
+ipv6_prefix: 2001:bf7:750:3f00::/56
+
 uplink:
   ifname: eth0
   ipv4: 77.87.49.8/28

--- a/host_vars/ohlauer-gw/gateway.yml
+++ b/host_vars/ohlauer-gw/gateway.yml
@@ -1,4 +1,5 @@
 ---
+ipv6_prefix: 2001:bf7:830:8300::/56
 
 uplink:
   ifname: lan0

--- a/host_vars/saarbruecker-gw/gateway.yml
+++ b/host_vars/saarbruecker-gw/gateway.yml
@@ -1,4 +1,5 @@
 ---
+ipv6_prefix: 2001:bf7:760:2201::/56
 
 uplink:
   ifname: lan3

--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -8,9 +8,9 @@ config interface 'loopback'
 	option ipaddr '127.0.0.1'
 	option netmask '255.0.0.0'
 {% if role == 'corerouter' %}
-	option dns '{{ dns_servers | join(' ') }}'
+  option dns '{{ dns_servers | join(' ') }}'
   {% if ipv6_prefix is defined %}
-	option ip6addr '{{ ipv6_prefix }}'
+  option ip6addr '{{ ipv6_prefix }}'
   {% endif %}
 {% endif %}
 

--- a/roles/cfg_openwrt/templates/uplink_gateway/config/babeld.j2
+++ b/roles/cfg_openwrt/templates/uplink_gateway/config/babeld.j2
@@ -33,14 +33,10 @@ config filter
 	option 'proto'	'12'
 	option 'action' 'src-prefix {{ freifunk_global_prefix }}'
 
-{% if mgmt is defined %}
-# Redistribute local MGMT prefix
 config filter
 	option 'type'	'redistribute'
-	option 'local'  'true'
-	option 'ip'	'{{ mgmt['ipv6'] | ipaddr('network/prefix') }}'
-	option 'eq'	'{{ mgmt['ipv6'] | ipaddr('prefix') }}'
-{% endif %}
+	option 'ip'	'{{ ipv6_prefix }}'
+	option 'eq'	'{{ ipv6_prefix | ipaddr('prefix') }}'
 
 # Finally Prohibit distribution of all local networks. (.. but allow non-local networks, e.g learned via tunnel)
 config filter

--- a/roles/cfg_openwrt/templates/uplink_gateway/config/network.j2
+++ b/roles/cfg_openwrt/templates/uplink_gateway/config/network.j2
@@ -4,6 +4,9 @@ config interface 'loopback'
 	option ipaddr '127.0.0.1'
 	option netmask '255.0.0.0'
 	option dns '{{ dns_servers | join(' ') }}'
+{% if ipv6_prefix is defined %}
+	option ip6addr '{{ ipv6_prefix }}'
+{% endif %}
 
 config interface 'uplink'
 	option ifname '{{ uplink['ifname'] }}'


### PR DESCRIPTION
Fixes: #99 (" Why is the ipv6 prefix not assigned to lo-interface for up-link gateways?")