### PR TITLE
Two *.olsr domain name fixes

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
@@ -18,6 +18,15 @@ config dnsmasq
         list server '{{ _dns_server }}'
 {% endfor %}
 
+{% for network in networks | selectattr('role', 'equalto', 'mgmt') %}
+  {% for host, ip_num in network['assignments'].items() %}
+config domain '{{ host | replace('-', '_') }}_olsr'
+	option name '{{ host }}.olsr'
+	option ip '{{ network['prefix'] | ansible.utils.ipaddr(ip_num) | ansible.utils.ipaddr('address') }}'
+
+  {% endfor %}
+{% endfor %}
+
 {% for network in networks | rejectattr('role', 'in', ['ext', 'mesh']) %}
     {% set name = network['name'] if 'name' in network else network['role'] %}
 


### PR DESCRIPTION
dnsmasq: define .olsr domains independently of OLSRd

> Previously, dnsmasq would only pick up our own .olsr domain names
> once OLSR had first flushed its nameservice hosts file, and once
> dnsmasq actually reloaded its config. This could take up to 5 minutes.
> Until then, our own .olsr domains were not resolvable.
> 
> We now explicitly tell dnsmasq about our own .olsr domain names.
> As a result, they can be resolved instantly once dnsmasq is running.
> 
> Neat side effect: proper .olsr hostnames in Reverse DNS and traceroute.
> Before this patch, the first hop would only report as 'frei.funk'.

dnsmasq: never forward .olsr queries to public resolvers

> Queries for *.olsr should never be forwarded to public resolvers.
> Some resolvers drop queries for unknown TLDs, without a response.
> 
> As a result, our query waits for a long time and eventually times out.
> This affects A queries for unknown hosts, and also all AAAA queries.
> 
> Happy Eyeballs means an AAAA query is sent almost always,
> even though *.olsr is really only used for our IPv4 networking,
> and so we get lots of very slow DNS queries...
> 
> This can be avoided very simply by not forwarding .olsr queries.
