### PR TITLE
gateway: allow incoming iperf3 sessions

### DIFF
--- a/roles/cfg_openwrt/templates/gateway/config/firewall.j2
+++ b/roles/cfg_openwrt/templates/gateway/config/firewall.j2
@@ -107,6 +107,12 @@ config rule
 	option dest_port	'{{ wireguard_port_start }}':'{{ wireguard_port_end }}'
 	option target		ACCEPT
 
+config rule
+	option name		"Allow iperf3"
+	option src		uplink
+	option dest_port	5201
+	option target		ACCEPT
+
 # Allow essential incoming IPv6 ICMP traffic
 config rule
 	option name		Allow-ICMPv6-Input


### PR DESCRIPTION
I was curious how much uplink load our gateways can handle:

2.6g rx, 1.7g tx - dest 77.87.51.11 ak36
2.6g rx, 1.6g tx - dest 77.87.49.8 l105
850m rx, 550m tx - dest 176.74.57.19 ohlauer
380m rx, 420m tx - dest 176.74.57.43 saarbruecker
900m rx, 900m tx - dest 77.87.51.131 strom