### PR TITLE
zwingli: fix mgmt for dome-1

### DIFF
--- a/locations/zwingli.yml
+++ b/locations/zwingli.yml
@@ -274,7 +274,7 @@ networks:
       zwingli-west-nf-5ghz: 17
 
       # dome inside church
-      # zwingli-dome-1: 18  # defect as of 01/24
+      zwingli-dome-1: 18
       zwingli-dome-2: 19
 
       # 5ghz sectors


### PR DESCRIPTION
When the AP was brought back up the mgmt-part was still commented out resulting in the AP not being reachable but otherwise working. I didnt flash the Core so far.