### PR TITLE
sav: added switchconfig, changed corerouter

### DIFF
--- a/locations/sav.yml
+++ b/locations/sav.yml
@@ -17,19 +17,66 @@ contacts:
 ipv6_prefix: 2001:bf7:830:ae00::/56
 
 hosts:
-
   - hostname: sav-core
     role: corerouter
-    model: x86-64
+    model: "mikrotik_routerboard-750gr3"
+    host__rclocal__to_merge:
+      - '#'
+      - '# This script adjusts the configuration of vlans. This is especially'
+      - '# useful with uswflex and custom port configs'
+      - '#'
+      - ' '
+      - '. /lib/functions.sh'
+      - ' '
+      - 'handle_vlans() {'
+      - '	# untag the vlans on different ports based on their id'
+      - '	local uci_section="$1"'
+      - ' '
+      - '	config_get vlan "$uci_section" vlan'
+      - '	config_get ports "$uci_section" ports'
+      - ' '
+      - ' '
+      - '	case "$vlan" in'
+      - '		10)'
+      - '			# untag payload traffic for Wave to Emma'
+      - "			port_config='wan lan2:t lan3:t lan4:t lan5:t' ;;"
+      - '		40)'
+      - '			# untag DHCP on port 2'
+      - "			port_config='wan:t lan2 lan3:t lan4:t lan5:t' ;;"
+      - '		50)'
+      - '			# untag port 3 for local backup uplink'
+      - "			port_config='wan:t lan2:t lan3 lan4:t lan5:t' ;;"
+      - '		*)'
+      - '			# do nothing for the other vlans'
+      - '			return'
+      - '	esac'
+      - ' '
+      - '	# abort if config is applied already'
+      - '	if [ "$ports" = "$port_config" ]; then'
+      - '		printf "Vlan %d applied already.\n" "$vlan"'
+      - '		return'
+      - '	fi'
+      - ' '
+      - '	printf "Port number: %d\n" "$vlan"'
+      - '	printf "Port config: %s\n" "$port_config"'
+      - ' '
+      - '	printf "Configuring %s... " "$uci_section"'
+      - '	uci_set network "$uci_section" ports "$port_config"'
+      - '	printf "Done.\n"'
+      - '}'
+      - ' '
+      - 'config_load network'
+      - ' '
+      - 'config_foreach handle_vlans "bridge-vlan"'
+      - ' '
+      - 'uci commit network'
 
 snmp_devices:
-
   - hostname: sav-emma
     address: 10.31.174.242
     snmp_profile: af60
 
 networks:
-
   - vid: 10
     role: mesh
     name: mesh_emma
@@ -38,7 +85,6 @@ networks:
 
   - vid: 40
     role: dhcp
-    untagged: true
     inbound_filtering: true
     enforce_client_isolation: true
     prefix: 10.31.174.248/30
@@ -57,9 +103,7 @@ networks:
       sav-emma: 2
 
   - vid: 50
-    ifname: eth1
     role: uplink
-    untagged: true
 
   - role: tunnel
     ifname: ts_wg0


### PR DESCRIPTION
~~**EDIT: The second commit with the reload still needs to be fully tested**~~ -> removed 2nd commit to bring the current state into `main`, i will continue to investigate this with low priority as we can easily recover a device afterwards and this is highly custom solution that will eventually a feature in bbb-configs anyways

The requirement from the location is as you can see below, so i added a custom switch config based on @Akira25 's script for `ilr`.

Port 1: Connection to Emma
Port 2: DHCP for Clients
Port 3: Local Backup

![image (1)](https://github.com/user-attachments/assets/143619b9-b747-4b69-9229-3a0ab3178098)
