### PR TITLE
corerouter: only log errors for bird instead of all

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/bird.conf.j2
+++ b/roles/cfg_openwrt/templates/corerouter/bird.conf.j2
@@ -1,7 +1,7 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "true"
 {% import 'libraries/network.j2' as libnetwork with context %}
 
-log syslog all;
+log syslog {error};
 debug protocols {states};
 
 # Include additional bird config files for runtime extendability


### PR DESCRIPTION
This makes the logs useable again. If you need more logging infos you can manually edit `/etc/bird.conf` back to `all` for debugging.