### PR TITLE
tasks (imagebuilder): add comment explaining local imagebuilder

### DIFF
--- a/roles/cfg_openwrt/tasks/imagebuilder.yml
+++ b/roles/cfg_openwrt/tasks/imagebuilder.yml
@@ -33,6 +33,8 @@
     mode: "644"
   when: '"http" in imagebuilder'
 
+# For testing purposes the imagebuilder variable can be replaced with a path to a local file.
+# This task takes care of using this file instead of trying to download something
 - name: Copy Local Imagebuilder
   command:
     argv:


### PR DESCRIPTION
As I stumbled across this in the last days I added a comment explaining what this section does as it wasnt immediately clear for me.