### PR TITLE
K9 hardware upgrade

### DIFF
--- a/group_vars/model_aruba_ap_303.yml
+++ b/group_vars/model_aruba_ap_303.yml
@@ -1,0 +1,19 @@
+---
+target: ipq40xx/generic
+brand_nice: Aruba
+model_nice: Instant On AP11
+
+dsa_ports:
+  - lan
+
+wireless_devices:
+  - name: 11a_standard
+    band: 5g
+    htmode_prefix: VHT
+    path: platform/soc/a800000.wifi
+    ifname_hint: wlan5
+  - name: 11g_standard
+    band: 2g
+    htmode_prefix: HT
+    path: platform/soc/a000000.wifi
+    ifname_hint: wlan2

--- a/locations/k9.yml
+++ b/locations/k9.yml
@@ -13,18 +13,22 @@ hosts:
     role: corerouter
     model: "avm_fritzbox-7530"
     wireless_profile: freifunk_default
+  - hostname: k9-ap-loge
+    role: ap
+    model: "aruba_ap-303"
+    wireless_profile: freifunk_default
+  - hostname: k9-ap-groessenwahn
+    role: ap
+    model: "aruba_ap-303"
+    wireless_profile: freifunk_default
 
 snmp_devices:
   - hostname: k9-sama
-    address: 10.31.9.211
-    snmp_profile: airos_8
+    address: 10.31.9.243
+    snmp_profile: af60
 
   - hostname: k9-zwingli
-    address: 10.31.9.212
-    snmp_profile: airos_6
-
-  - hostname: k9-wilgu10
-    address: 10.31.9.213
+    address: 10.31.9.244
     snmp_profile: airos_8
 
 ipv6_prefix: '2001:bf7:830:8d00::/56'
@@ -33,11 +37,8 @@ ipv6_prefix: '2001:bf7:830:8d00::/56'
 # 10.31.9.0/24
 
 # - 10.31.9.0/25 - DHCP
-# - 10.31.9.208/28 - MGMT
 # - 10.31.9.224/28 - BBB-Mesh
-# - 10.31.9.240/28 - Internal Mesh
-
-# 10.31.99.0/24 / can be proably dismantled
+# - 10.31.9.240/28 - MGMT
 
 networks:
   # MESH - Sama
@@ -45,60 +46,17 @@ networks:
     role: mesh
     name: mesh_sama
     prefix: 10.31.9.224/32
-    ipv6_subprefix: -10
-    ptp: true
+    ipv6_subprefix: -1
+    mesh_metric: 128
 
   # MESH - Zwingli
   - vid: 11
     role: mesh
     name: mesh_zwingli
     prefix: 10.31.9.225/32
-    ipv6_subprefix: -11
+    ipv6_subprefix: -2
     mesh_metric: 1024
-    mesh_metric_lqm: ['default 0.6']
-    ptp: true
-
-  # MESH - Wilgu10
-  - vid: 12
-    role: mesh
-    name: mesh_wilgu10
-    prefix: 10.31.9.226/32
-    ipv6_subprefix: -12
-    ptp: true
-
-  # MESH - LAN via Powerline
-  - vid: 20
-    role: mesh
-    name: mesh_k9int
-    prefix: 10.31.9.240/28
-    ipv6_subprefix: -20
-    mesh_metric: 128
-    mesh_metric_lqm: ['default 0.2']
-    # Ignore Uplink one Hop away / requires 0.2 LQM
-    assignments:
-      k9-core: 1
-
-  # MESH - 5 GHz 802.11s
-  - vid: 21
-    role: mesh
-    name: mesh_5g
-    prefix: 10.31.9.227/32
-    ipv6_subprefix: -21
-    mesh_ap: k9-core
-    mesh_radio: 11a_standard
-    mesh_iface: mesh
-
-  # MESH - 2.4 GHz 802.11s
-  - vid: 22
-    role: mesh
-    name: mesh_2g
-    prefix: 10.31.9.228/32
-    ipv6_subprefix: -22
-    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.5']
-    mesh_ap: k9-core
-    mesh_radio: 11g_standard
-    mesh_iface: mesh
 
   # DHCP
   - vid: 40
@@ -111,21 +69,21 @@ networks:
       k9-core: 1
 
   # MGMT
-  - vid: 42
+  - vid: 439
     role: mgmt
-    prefix: 10.31.9.208/28
+    prefix: 10.31.9.240/28
     gateway: 1
     dns: 1
     ipv6_subprefix: 1
     assignments:
-      k9-core: 1      # 10.31.9.209
-      # k9-switch: 2  # 10.31.9.210
-      k9-sama: 3      # 10.31.9.211
-      k9-zwingli: 4   # 10.31.9.212
-      k9-wilgu10: 5   # 10.31.9.213
+      k9-core: 1
+      k9-switch-roof: 2 # uisp-s
+      k9-sama: 3 # wave nano
+      k9-zwingli: 4
+      k9-switch-house: 8 # hpe 2520g-poe
+      k9-ap-loge: 9
+      k9-ap-hinterhaus: 10
 
 location__ssh_keys__to_merge:
-  - comment: k9 JuergeN
-    key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDQe6dpUP7ame5ndvnQpghI/OVWav52ggbgwbdZ56Tr1q0bZQzuHNzwgRUrMiOtNbeN6AYQtLF2kEn1v0fLGp1twYiCFbc5GZV7Do5aDyqK71gDo2b0/EQ0pc/AeXnt4XoEfW1k6USCvGgAwUsVRJgHd1b+1+rrfdFH4qF8JatUYbcNDhS/hf6pUwQFEUJ+OdCFMgxbNYScnvf3UR5ttBq+Ur6yiYq1qi7zupVne9RKrCZMqaq0pdQGx9t8TOF3dskN5EWqn0GDCNOZZmf1VC1KhfhngE3/SYCqOAxSSXIUpLehL1KI05xhWVSzt0ngRVzgxySBsDxdJw8go/scisDB99Pfh+cSsHylHWW4JUEaIaZpMIpqydYElnyuZffr02C4tqdht18bc0lom0YcknYJ+UeBkBpRa3ii+WiANGBcs5j5+tUlu3GlWDHWE/gBj/FSp1X/FOCg6vhYO7nMdQa59ZIps/Y1NFlmKB7jwX76dj5Z8M8ZRmofSlbC2D3PKaQdYrbtVGWRqbVBpE8w0hw4zraKs7mpq1EHLN7gcDmkFoxaqWi1mU30Y3m8eltzspycHbyotq+djKF3zxlA6zR1eAexG7e+BYknMKqHiXMwP+cF6Tmr0rpaAHbBqeO3gXk5AhtIGLGGvdyAitgfmlVG0xVcgz2FeTPu3/RCgtpSOQ==
-  - comment: k9 Silke
-    key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCkyugPN8XIgxZ/l9fRPbcXrR042/XzX4T7PGP49ffHEDF8O0thI4tiils8LDkSJGpOtwPd1BPPgTT3YDm0Biy+HaeTtEEmVUs7AmRjl5sPcUXwPwMUXl9DKHBzpYKAfb6Jy2pBos7eswtFLHAS2tziyhREMz8OJuh9qZ9fs32BG+6AEGFL1hs4evI+NFtokcW7HW28zhkq2+NWi1kKef0SRY0rX9Kfp6fkMc5XKCZPuWBz97ZMCvUKShBiZXVJj6QzNxjaBcVnMCB/oqLxfrs2FrUbvNDcb2bAamyYLCVaU0DKtefByuBhsrrRdD35Ahi+qh1FFC1X59j1ozZX7Xq/
+  - comment: k9 iuljan
+    key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO0hqsAl0BJGlVgARU0KcE2JD+ljlOJebbFn4NI1aAlQ freifunk-k9@iuljan-m3


### PR DESCRIPTION
This PR contains the customized configs for the hardware change at location k9.

A 60GHZ antenna is aligned to Sama
And the previous one is aligned to Zwingli
POE rooftop switch supplied by POE-injection in the basement.

Loge and Größenwahn get core APs (Aruba AP11) via LAN.