### PR TITLE
tempelwg: workaround for switch link issue on D-Link COVR-X1860

### DIFF
--- a/locations/tempelwg.yml
+++ b/locations/tempelwg.yml
@@ -14,6 +14,8 @@ hosts:
     wireless_profile: tempelwg
     host__rclocal__to_merge:
       - 'cat /etc/crontabs/root | grep reboot 2>/dev/null || echo "0 4 * * * reboot" >> /etc/crontabs/root && /etc/init.d/cron restart'
+      - 'ethtool --set-eee internet eee off tx-lpi off'
+      - 'ethtool --set-eee ethernet eee off tx-lpi off'
 
   - hostname: tempelwg-ap-tini
     role: ap


### PR DESCRIPTION
There is a periodic link up/down issue. As a workaround, disable EEE (Energy Efficient Ethernet).
See https://github.com/openwrt/openwrt/issues/17351 for more details.