### PR TITLE
templates: resolve roaming and FDB entry issues

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/dsa.network.inc
+++ b/roles/cfg_openwrt/templates/common/config/dsa.network.inc
@@ -1,13 +1,25 @@
 config device
 	option type 'bridge'
 	option name 'switch0'
+	option vlan_filtering '1'
+  {% set portmapping = [] %}
+  {% for port in dsa_ports %}
+    {% set _ = portmapping.append(port) %}
+  {%- endfor %}
+	option ports '{{ portmapping|join(' ') }}'
 
 {% for network in networks | selectattr('vid', 'defined') | selectattr('ifname', 'undefined') %}
   {% set portmapping = [] %}
   {% for port in dsa_ports %}
     {% set tagged = not network.get('untagged') %}
-    {{ portmapping.append(port|string + (":t" if tagged else "")) }}
+    {{ portmapping.append(port|string + (":t" if tagged else ":u*")) }}
   {%- endfor %}
+
+config device
+	option type '8021q'
+	option ifname 'switch0'
+	option vid '{{ network['vid'] }}'
+	option name 'switch0.{{ network['vid'] }}'
 
 config bridge-vlan 'vlan_{{ network['vid'] }}'
 	option device 'switch0'


### PR DESCRIPTION
We previously experienced roaming issues where FDB entries would become
incorrect when a client switched between APs, causing connectivity issues
until the erroneous FDB entry expired after 5 minutes [0-3]. Initially, this
was thought to be a bug, but after discussions between @spolack and @f00b4r0,
it became clear that the configuration was likely incorrect [4].

To fix this, we now explicitly define all ports and set the VLAN filtering
to enabled on the bridge device. Additionally, each device's VLAN type is
set to '8021q' with the corresponding VID, and the ":u*" syntax is used for
untagged ports.

This configuration update should eliminate or at least work around the FDB
entry errors and fix roaming behavior.

Before:
```
config device
	option type 'bridge'
	option name 'switch0'

config bridge-vlan 'vlan_40'
	option device 'switch0'
	option vlan '40'
	option ports 'internet:t ethernet:t'

config bridge-vlan 'vlan_50'
	option device 'switch0'
	option vlan '50'
	option ports 'internet ethernet'
```

After:
```
config device
	option type 'bridge'
	option name 'switch0'
	option vlan_filtering '1'
	option ports 'internet ethernet'

config device
	option type '8021q'
	option ifname 'switch0'
	option vid '40'
	option name 'switch0.40'

config bridge-vlan 'vlan_40'
	option device 'switch0'
	option vlan '40'
	option ports 'internet:t ethernet:t'

config device
	option type '8021q'
	option ifname 'switch0'
	option vid '50'
	option name 'switch0.50'

config bridge-vlan 'vlan_50'
	option device 'switch0'
	option vlan '50'
	option ports 'internet:u* ethernet:u*'
```

[0] - https://github.com/openwrt/openwrt/issues/11650
[1] - https://github.com/openwrt/openwrt/issues/11218
[2] - https://github.com/openwrt/openwrt/issues/11277
[3] - https://github.com/openwrt/openwrt/issues/11029
[4] - https://oftc.irclog.whitequark.org/openwrt-devel/2025-01-28