### PR TITLE
Revert "model: bump usw-flex to 24.10"

### DIFF
--- a/group_vars/model_ubnt_usw_flex.yml
+++ b/group_vars/model_ubnt_usw_flex.yml
@@ -11,8 +11,6 @@ target: ramips/mt7621
 brand_nice: Ubiquiti
 model_nice: USW-Flex
 
-openwrt_version: 24.10-SNAPSHOT
-
 dsa_ports:
   - lan1
   - lan2


### PR DESCRIPTION
This reverts commit a60c74705b9f4988f969bc5ff34e21e2bc024190.

The poemgr GPIO fix is incomplete, we need to roll back until the proper fix is in place. See https://github.com/blocktrron/poemgr/pull/12