### PR TITLE
treewide: enable mesh_nolearn

### DIFF
--- a/group_vars/all/wireless_profiles.yml
+++ b/group_vars/all/wireless_profiles.yml
@@ -26,6 +26,7 @@ all__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh
 
   - name: ap_only
@@ -67,6 +68,7 @@ all__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh
 
   - name: freifunk_fw
@@ -91,6 +93,7 @@ all__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh
 
   - name: freifunk_hacrafu
@@ -115,4 +118,5 @@ all__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh

--- a/locations/colbe15.yml
+++ b/locations/colbe15.yml
@@ -99,4 +99,5 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh

--- a/locations/friedland3.yml
+++ b/locations/friedland3.yml
@@ -131,4 +131,5 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh

--- a/locations/funkigel.yml
+++ b/locations/funkigel.yml
@@ -162,4 +162,5 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh

--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -140,4 +140,5 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh

--- a/locations/k6b.yml
+++ b/locations/k6b.yml
@@ -116,6 +116,7 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh
 
 # DNS Servers

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -211,4 +211,5 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh

--- a/locations/kirchhof.yml
+++ b/locations/kirchhof.yml
@@ -158,4 +158,5 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh

--- a/locations/muggel.yml
+++ b/locations/muggel.yml
@@ -110,4 +110,5 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh

--- a/locations/noki.yml
+++ b/locations/noki.yml
@@ -225,6 +225,7 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh
 
 # DNS Servers

--- a/locations/tempelwg.yml
+++ b/locations/tempelwg.yml
@@ -132,6 +132,7 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh
 
 dns_servers:

--- a/locations/w38b.yml
+++ b/locations/w38b.yml
@@ -216,6 +216,7 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard, 11a_mesh]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh
 
 # DNS-Servers

--- a/locations/wilgu10.yml
+++ b/locations/wilgu10.yml
@@ -180,6 +180,7 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard]
         mcast_rate: 12000
         mesh_fwding: 0
+        mesh_nolearn: 1
         ifname_hint: mesh
 
 dns_servers:

--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -131,6 +131,9 @@ config wifi-iface '{{ wd_id }}_if{{ loop.index0 }}'
       {% if 'mesh_fwding' in iface %}
 	option mesh_fwding '{{ iface['mesh_fwding'] }}'
       {% endif %}
+      {% if 'mesh_nolearn' in iface %}
+	option mesh_nolearn '{{ iface['mesh_nolearn'] }}'
+      {% endif %}
       {% if 'mcast_rate' in iface %}
 	option mcast_rate '{{ iface['mcast_rate'] }}'
       {% endif %}


### PR DESCRIPTION
Disable 802.11s path discovery because we run our own mesh routing daemon.