### PR TITLE
c-base: replaced nanobeam with af60lr

### DIFF
--- a/locations/c-base.yml
+++ b/locations/c-base.yml
@@ -38,9 +38,9 @@ snmp_devices:
     address: 10.31.134.98
     snmp_profile: edgeswitch
 
-  - hostname: c-base-mesh-ssw
+  - hostname: c-base-simeon-af60lr
     address: 10.31.134.101
-    snmp_profile: airos_8
+    snmp_profile: af60
 
   - hostname: c-base-simeon60
     address: 10.31.134.104
@@ -68,17 +68,19 @@ networks:
 
   - vid: 11
     role: mesh
-    name: mesh_simeon
+    name: simeon_af60
     prefix: 10.31.134.112/32
     ipv6_subprefix: -11
+    mesh_metric: 128
+    ptp: true
 
   - vid: 12
     role: mesh
-    name: mesh_sim60
+    name: simeon_wave
     prefix: 10.31.134.117/32
     ipv6_subprefix: -12
     ptp: true
-    mesh_metric: 128
+    mesh_metric_lqm: ["default 0.5"]
 
   - vid: 20
     role: mesh
@@ -118,7 +120,7 @@ networks:
       c-base-switch: 2 # 10.31.134.98
       c-base-nf-1: 3 # 10.31.134.99
       c-base-nf-2: 4 # 10.31.134.100
-      c-base-simeon: 5 # 10.31.134.101
+      c-base-simeon-af60lr: 5 # 10.31.134.101
       c-base-nf-3: 6 # 10.31.134.102
       c-base-nf-4: 7 # 10.31.134.103
       c-base-simeon60: 8 # 10.31.134.104


### PR DESCRIPTION
 let's prefer the af60 and keep the waveap as a backup to see if the performance is sufficient