### PR TITLE
fix collectd generating too large packages

### DIFF
--- a/roles/cfg_openwrt/templates/common/collectd/conf.d/basic.conf.j2
+++ b/roles/cfg_openwrt/templates/common/collectd/conf.d/basic.conf.j2
@@ -22,6 +22,8 @@ LoadPlugin network
 	Server "{{ collectd_host }}"
 	Forward false
 	ReportStats false
+	# Set MaxPacketSize because packages got dropped due to being to big
+	MaxPacketSize 1280
 </Plugin>
 
 


### PR DESCRIPTION
Without this option collectd created packages that where to big resulting in the error "network plugin: sendto failed: Message too large. Closing sending socket."

This size limits the package to the same value as the mtu for tunnels. We could optimize the Value in the future, but for now it works.

This problem affected newyorck-core