### PR TITLE
mgh: update to 24.10

### DIFF
--- a/locations/mgh.yml
+++ b/locations/mgh.yml
@@ -10,7 +10,7 @@ community: true
 hosts:
   - hostname: mgh-core
     role: corerouter
-    model: "ubnt_edgerouter-x-sfp"
+    model: "ubnt_edgerouter-x-sfp-24-10"
     poe_on: [2]
 
 snmp_devices:
@@ -47,9 +47,3 @@ networks:
     untagged: true
     assignments:
       mgh-core: 1
-
-# location__channel_assignments_11a_standard__to_merge:
-#  mgh-core: 36-20-15
-
-# location__channel_assignments_11g_standard__to_merge:
-#  mgh-core: 1-20


### PR DESCRIPTION
This PR allows to build 24.10 firmware for an Edgerouter X SFP that was manually converted to the new partition layout that is required to run 24.10.