### PR TITLE
emma: remove unused mesh vlan

### DIFF
--- a/locations/emma.yml
+++ b/locations/emma.yml
@@ -177,12 +177,6 @@ networks:
     prefix: 10.31.11.35/32
     ipv6_subprefix: -12
 
-  - vid: 13
-    role: mesh
-    name: mesh_ono
-    prefix: 10.31.11.36/32
-    ipv6_subprefix: -13
-
   - vid: 14
     role: mesh
     name: mesh_wsw


### PR DESCRIPTION
That 5 GHz mesh sector has been replaced with a 60 GHz Wave AP on a separate VLAN.