### PR TITLE
zwingli,baumex: add lqm to avoid OLSR route flapping

### DIFF
--- a/locations/baumex.yml
+++ b/locations/baumex.yml
@@ -123,6 +123,8 @@ networks:
     name: mesh_lan_lte
     prefix: 10.248.28.166/32
     ipv6_subprefix: -30
+    # Ajust link metric to prefer other OLSR gateways
+    mesh_metric_lqm: ["default 0.75"]
 
   # DHCP with filtering and isolation
   - vid: 40

--- a/locations/zwingli.yml
+++ b/locations/zwingli.yml
@@ -150,13 +150,16 @@ networks:
     name: mesh_west
     prefix: 10.31.115.35/32
     ipv6_subprefix: -4
+    # prefer OLSR routing via sama over gub37 during issues with zwingli<->emma link
+    mesh_metric_lqm: ["default 0.5"]
+
 
   - vid: 14
     role: mesh
     name: mesh_sama
     prefix: 10.31.115.36/32
     ipv6_subprefix: -5
-    # prefer routing via emma over sama to use ohlauer as gateway)
+    # prefer routing via emma over sama to use ohlauer as gateway
     mesh_metric: 256
     mesh_metric_lqm: ["default 0.5"]
     ptp: true


### PR DESCRIPTION
This PR introduces LQM metrics to avoid route flapping for OLSR only nodes connected to zwingli. The goal is to provide a stable route via sama->saarbruecker until zwingli<->emma is fixed and traffic will flow via emma->ohlauer again.