### PR TITLE
ohlauer: disable uhttpd to hide ubus

### DIFF
--- a/locations/ohlauer.yml
+++ b/locations/ohlauer.yml
@@ -11,6 +11,8 @@ hosts:
   - hostname: ohlauer-gw
     role: gateway
     model: "ubnt_edgerouter-4"
+    host__disabled_services__to_merge:
+      - uhttpd
 
 snmp_devices:
   - hostname: ohlauer-switch


### PR DESCRIPTION
This host is stuck at 23.05 which won't get the ubus security fix. Let's turn off uhttpd here so ubus isn't exposed to the internet.