### PR TITLE
snmp_profiles: fixed af60 according to MIB rev1 in new AirOS 10 release

### DIFF
--- a/group_vars/all/snmp_profiles.yml
+++ b/group_vars/all/snmp_profiles.yml
@@ -12,12 +12,12 @@ collectd_snmp_profiles:
       Type: frequency
       TypeInstance: "Frequency (MHz)"
       Table: false
-      Values: .1.3.6.1.4.1.41112.1.11.1.1.2.1
+      Values: .1.3.6.1.4.1.41112.1.11.2.1.2.1
     rf_width:
       Type: frequency
       TypeInstance: "Channel Width (MHz)"
       Table: false
-      Values: .1.3.6.1.4.1.41112.1.11.1.1.3.1
+      Values: .1.3.6.1.4.1.41112.1.11.2.1.3.1
     rf_sta_distance:
       PluginInstance: distance
       Type: gauge


### PR DESCRIPTION
New mib was released together with 4.1.0-rc

This fixes #1426

Already deployed to rhnk. I decided to not intruduce a new profile as all airos-devices will be updated soonish anyways