### PR TITLE
templates:dhcp: add hostname to config host section

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
@@ -64,7 +64,7 @@ config dhcp 'dhcp_{{ name }}'
 
 {% for network in networks | selectattr('role','equalto','dhcp') %}
     {% for assignment in network['assignments'] %}
-config host
+config host '{{ assignment.replace("-", "_") }}'
 	option name '{{ assignment }}'
 	option ip '{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][assignment]) | ansible.utils.ipaddr('address') }}'
     {% endfor %}


### PR DESCRIPTION
This fixes #1433

I didnt added it to the gateways, only core routers, as they dont have `config host` in them. 

Before:
```
config host
	option name 'rhnk-core'
	option ip '10.230.3.65'
```

After:
```
config host 'rhnk-core'
	option name 'rhnk-core'
	option ip '10.230.3.65'
```

I couldnt find this syntax in the [official documentation](https://openwrt.org/docs/guide-user/base-system/dhcp?s[]=0&s[]=0.#static_leases), but assume it should be right as it was working before with @pmelange 