### PR TITLE
template:tunspace: add deterministic mac

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/tunspace.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/tunspace.j2
@@ -19,6 +19,8 @@ config tunspace "tunspace"
   option uplink_ipv4 "{{ uplink['uplink_ipv4']|default('') }}"
   # IPv4 address of the gateway. Required in combination with uplink_ipv4, ignored when using DHCP.
   option uplink_gateway "{{ uplink['uplink_gateway']|default('') }}"
+  # Define deterministic mac address
+  option uplink_mac "{{- libnetwork.generateDeterministicMAC(inventory_hostname ~ "-tunspace") -}}"
   # Maintenance consists of checking the uplink, refreshing the DHCP lease, checking the tunnel endpoints, and switching endpoints if neccessary.
   option maintenance_interval 60
   # Enables detailed output of Tunspace's operations. If disabled, only tunnel endpoint changes are reported.


### PR DESCRIPTION
Add option in configs for a deterministic mac similar to [existing approaches](https://github.com/freifunk-berlin/bbb-configs/blob/512bdbe29fb7b76256b3dac50ad70a592772c614/roles/cfg_openwrt/templates/common/config/network.j2#L57-L60). This option can later be used in tunspace package. [Corresponding change there](https://github.com/freifunk-berlin/falter-packages/pull/493)