### PR TITLE
model: bump tplink archer c50 v4 to 25.12, set to low mem/flash

### DIFF
--- a/group_vars/model_tplink_archer_c50_v4.yml
+++ b/group_vars/model_tplink_archer_c50_v4.yml
@@ -3,6 +3,7 @@ target: ramips/mt76x8
 brand_nice: TP-Link
 model_nice: Archer C50
 version_nice: v4
+openwrt_version: 25.12-SNAPSHOT
 
 switch_ports: 7
 switch_int_port: 6

--- a/group_vars/model_tplink_archer_c50_v4.yml
+++ b/group_vars/model_tplink_archer_c50_v4.yml
@@ -4,12 +4,13 @@ brand_nice: TP-Link
 model_nice: Archer C50
 version_nice: v4
 
-openwrt_version: 23.05-SNAPSHOT
-
 switch_ports: 7
 switch_int_port: 6
 switch_ignore_ports: [5]
 int_port: eth0
+
+low_mem: true
+low_flash: true
 
 wireless_devices:
   - name: 11a_standard


### PR DESCRIPTION
Hinweis: Der TP-Link kann aufgrund von geringem Speicher/Flash (nur) noch als AP für Standorte verwendet werden.

ToDo:

- [x] Test as AP - stable for:
  - [x] 6h
  - [x] 12h
  - [x] 1d
  - [x] 1w