### PR TITLE
models: add cudy wr3000e v1

### DIFF
--- a/group_vars/model_cudy_wr3000e_v1.yml
+++ b/group_vars/model_cudy_wr3000e_v1.yml
@@ -1,0 +1,24 @@
+---
+target: mediatek/filogic
+brand_nice: Cudy
+model_nice: WR3000E
+version_nice: v1
+
+dsa_ports:
+  - wan
+  - lan1
+  - lan2
+  - lan3
+  - lan4
+
+wireless_devices:
+  - name: 11a_standard
+    band: 5g
+    htmode_prefix: HE
+    path: platform/soc/18000000.wifi+1
+    ifname_hint: wlan5
+  - name: 11g_standard
+    band: 2g
+    htmode_prefix: HE
+    path: platform/soc/18000000.wifi
+    ifname_hint: wlan2


### PR DESCRIPTION
This one is different to the non e variant.
https://openwrt.org/toh/cudy/wr3000_v1
https://openwrt.org/toh/cudy/wr3000e