### PR TITLE
fix: Deploy community ssh-keys only if community is explicitly set

### DIFF
--- a/roles/cfg_openwrt/tasks/merge_vars.yml
+++ b/roles/cfg_openwrt/tasks/merge_vars.yml
@@ -22,7 +22,7 @@
     suffix_to_merge: __ssh_keys__to_merge
     merged_var_name: ssh_keys
     expected_type: list
-  when: ssh_keys is undefined
+  when: ssh_keys is undefined and (community is defined and community|bool == True)
 
 - name: Merge sysctl variable
   merge_vars:


### PR DESCRIPTION
Only deploy ssh keys ment for maintenance by the community if the community attribute is explicitly set. Otherwise an undefined community attribute deploys ssh keys silently and without warning on private installations. This new behavior seems to be inline with other uses of the community attribute in the code.

This change may break standard behavior and requires us to add another commit that adds the community attribute explicitly to all community maintained installations.