### PR TITLE
igh-ev: init location

### DIFF
--- a/locations/igh-ev.yml
+++ b/locations/igh-ev.yml
@@ -1,0 +1,75 @@
+---
+
+location: igh-ev
+location_nice: Selchower Straße 22, 12049 Berlin
+latitude: 52.47836105779351
+longitude: 13.420856025248085
+altitude: 80
+contact_nickname: "IGH e.V."
+contacts:
+  - "vorstand@ighamspirit.de"
+
+hosts:
+  - hostname: igh-ev-core  # PC Engines APU2 Board
+    role: corerouter
+    model: "x86-64"
+    int_port: eth0
+
+  - hostname: igh-ev-ap1 # Unifi AC Pro
+    role: ap
+    model: ubnt_unifiac_mesh
+
+snmp_devices:
+  - hostname: igh-ev-rhnk # Ubiquiti PowerBeam 5AC 300 ISO
+    address: 10.31.191.195
+    snmp_profile: airos_8
+
+  - hostname: igh-ev-flughafen # Ubiquiti PowerBeam 5AC 300 ISO
+    address: 10.31.191.196
+    snmp_profile: airos_8
+
+ipv6_prefix: "2001:bf7:820:3d00::/56"
+
+# igh-ev got following prefixes:
+# --MGMT: 10.31.191.192/29 (usable: .193 - .198)
+# --MESH: 10.31.191.200/29
+# --DHCP: 10.248.94.32/27
+
+networks:
+  # MESH - rhnk - Rathaus Neukölln
+  - vid: 10
+    role: mesh
+    name: mesh_rhnk
+    prefix: 10.31.191.200/32
+    ipv6_subprefix: -10
+    ptp: true
+
+  # MESH - flughafen - Flughafen Tempelhof (Bauteil B2)
+  - vid: 11
+    role: mesh
+    name: mesh_flughafen
+    prefix: 10.31.191.204/32
+    ipv6_subprefix: -11
+    ptp: true
+
+  - vid: 40
+    role: dhcp
+    prefix: 10.248.94.32/27
+    ipv6_subprefix: 1
+    assignments:
+      igh-ev-core: 1 # 10.248.94.33
+
+  - vid: 42
+    role: mgmt
+    prefix: 10.31.191.192/29
+    gateway: 1
+    dns: 1
+    ipv6_subprefix: 0
+    assignments:
+      igh-ev-core: 1 # 10.31.191.193
+      igh-ev-ap1: 2 # 10.31.191.194
+      igh-ev-rhnk: 3 # 10.31.191.195
+      igh-ev-flughafen: 4 # 10.31.191.196
+
+# Firewall fallback mgmt IP (not managed here):
+# igh-ev-fw: 10.31.191.197


### PR DESCRIPTION
Adds new location igh-ev (Selchower Straße 22, 12049 Berlin) with core (x86_64/APU2), one AP and two mesh uplinks; includes SNMP devices (airos_8). Prefixes: MGMT 10.31.191.192/29, MESH 10.31.191.200/29, DHCP 10.248.94.32/27.