### PR TITLE
igh-ev: Add UniFi AC Pro model and update location

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -35,7 +35,7 @@ height: 13                                        # in meter above ground level
 
 ### contact details
 
-Please mind that a contact is mandatory. If you don't like to give your email address, you can use the link to the contact form, that you've got from [config.berlin.freifunk.net](https://config.berlin.freifunk.net). Locations maintained by the entire community can use `community: berlin` instead. This will set default community values.
+Please mind that a contact is mandatory. If you don't like to give your email address, you can use the link to the contact form, that you've got from [config.berlin.freifunk.net](https://config.berlin.freifunk.net). Locations maintained by the entire community can use `community: true` instead. This will set default community values.
 
 ```yml
 contact_name: 'Petrosilius Quaccus'

--- a/group_vars/community_berlin.yml
+++ b/group_vars/community_berlin.yml
@@ -1,6 +1,0 @@
----
-contact_name: 'Freifunk Engenieering Task Force'
-contact_nickname: 'FETF'
-contacts:
-  - 'info+{{ location }}@berlin.freifunk.net'
-homepage: https://berlin.freifunk.net

--- a/group_vars/model_ubnt_unifiac_pro.yml
+++ b/group_vars/model_ubnt_unifiac_pro.yml
@@ -1,0 +1,38 @@
+---
+
+target: "ath79/generic"
+brand_nice: Ubiquiti
+model_nice: UniFi AP AC Pro
+
+# wie bei den anderen UniFi-APs im Repo
+openwrt_version: "24.10.4"
+
+model__packages__to_merge:
+  - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"
+  - "kmod-ath10k ath10k-firmware-qca988x"
+
+# AC Pro nutzt swconfig (Switch vorhanden)
+# Port-Mapping (OpenWrt): Port 2 = Primary (MAIN), Port 3 = Secondary
+# CPU-Port ist typischerweise 0
+switch_ports: 7
+switch_int_port: 0
+switch_ignore_ports:
+ - 1
+ - 4
+ - 5
+ - 6
+
+# Interface, auf dem swconfig arbeitet
+int_port: "eth0"
+
+wireless_devices:
+  - name: 11g_standard
+    band: 2g
+    htmode_prefix: HT
+    path: "platform/ahb/18100000.wmac"
+    ifname_hint: wlan2
+  - name: 11a_standard
+    band: 5g
+    htmode_prefix: VHT
+    path: "pci0000:00/0000:00:00.0"
+    ifname_hint: wlan5

--- a/inventory/keyed_groups_stage_1.config
+++ b/inventory/keyed_groups_stage_1.config
@@ -14,6 +14,3 @@ keyed_groups:
 
   - prefix: role
     key: role
-
-  - prefix: community
-    key: community

--- a/locations/agym.yml
+++ b/locations/agym.yml
@@ -5,7 +5,7 @@ location_nice: Andreas Gymnasium
 latitude: 52.514169
 longitude: 13.433311
 altitude: 67
-community: berlin
+community: true
 
 hosts:
   - hostname: agym-core

--- a/locations/ak36.yml
+++ b/locations/ak36.yml
@@ -5,7 +5,7 @@ location_nice: Alboinkontor
 latitude: 52.46558
 longitude: 13.369589
 altitude: 75
-community: berlin
+community: true
 
 local_asn: 65023
 peer_asn: 44194

--- a/locations/ak36dev.yml
+++ b/locations/ak36dev.yml
@@ -4,7 +4,7 @@
 
 location: ak36dev
 location_nice: Alboinkontor Dev System
-community: berlin
+community: true
 development: true
 
 local_asn: 65023

--- a/locations/bilgi.yml
+++ b/locations/bilgi.yml
@@ -6,7 +6,7 @@ longitude: 13.41419
 altitude: 41
 height: 1
 contact_nickname: Bilgisaray Kollektiv
-community: berlin
+community: true
 
 hosts:
   - hostname: bilgi-core

--- a/locations/chris.yml
+++ b/locations/chris.yml
@@ -5,7 +5,7 @@ location_nice: "Christophoruskirche, Schuckertdamm 336-340, 13629 Berlin"
 latitude: 52.541461
 longitude: 13.267025
 altitude: 65
-community: berlin
+community: true
 
 hosts:
   - hostname: chris-core

--- a/locations/colbe15.yml
+++ b/locations/colbe15.yml
@@ -4,7 +4,7 @@ location_nice: Colbe15
 latitude: 52.513189
 longitude: 13.464245
 altitude: 50
-community: berlin
+community: true
 
 hosts:
   - hostname: colbe15-core

--- a/locations/dorfplatz.yml
+++ b/locations/dorfplatz.yml
@@ -5,7 +5,7 @@ location_nice: Dorfplatz
 latitude: 52.517924
 longitude: 13.457358
 altitude: 37
-community: berlin
+community: true
 
 hosts:
   - hostname: dorfplatz-core

--- a/locations/dragonkiez-adlerhalle.yml
+++ b/locations/dragonkiez-adlerhalle.yml
@@ -5,7 +5,7 @@ latitude: 52.495065429
 longitude: 13.387666941
 altitude: 35
 height: 2
-community: berlin
+community: true
 
 hosts:
   - hostname: dragonkiez-adlerhalle

--- a/locations/dragonkiez-buero.yml
+++ b/locations/dragonkiez-buero.yml
@@ -5,7 +5,7 @@ latitude: 52.494722496
 longitude: 13.387774229
 altitude: 35
 height: 2
-community: berlin
+community: true
 
 hosts:
   - hostname: dragonkiez-buero

--- a/locations/dragonkiez-dorfplatz.yml
+++ b/locations/dragonkiez-dorfplatz.yml
@@ -5,7 +5,7 @@ latitude: 52.495457349
 longitude: 13.386079073
 altitude: 35
 height: 2
-community: berlin
+community: true
 
 hosts:
   - hostname: dragonkiez-dorfplatz

--- a/locations/dragonkiez-kiezraum.yml
+++ b/locations/dragonkiez-kiezraum.yml
@@ -5,7 +5,7 @@ latitude: 52.494807413
 longitude: 13.387511373
 altitude: 35
 height: 2
-community: berlin
+community: true
 
 hosts:
   - hostname: dragonkiez-kiezraum

--- a/locations/dragonkiez-rathausblock-miami.yml
+++ b/locations/dragonkiez-rathausblock-miami.yml
@@ -5,7 +5,7 @@ latitude: 52.495855798
 longitude: 13.387956619
 altitude: 39
 height: 2
-community: berlin
+community: true
 
 hosts:
   - hostname: dragonkiez-rathausblock-miami

--- a/locations/emma.yml
+++ b/locations/emma.yml
@@ -4,7 +4,7 @@ location_nice: Emmaus-Kirche, Lausitzer Platz 8, 10997 Berlin
 latitude: 52.499825
 longitude: 13.431035
 altitude: 87
-community: berlin
+community: true
 
 hosts:
   # Lenovo 10T8S00S00 / Thinkcentre M720q, i5-8500T, 1x16 GB RAM, 256 GB NVMe

--- a/locations/fardf.yml
+++ b/locations/fardf.yml
@@ -4,7 +4,7 @@ location_nice: "Finanzamt Reinickendorf, Eichborndamm 208, 13403 Berlin"
 latitude: 52.5870976
 longitude: 13.324892521
 altitude: 75
-community: berlin
+community: true
 
 hosts:
   - hostname: fardf-core

--- a/locations/flughafen.yml
+++ b/locations/flughafen.yml
@@ -5,7 +5,7 @@ location_nice: Flughafen Tempelhof (Bauteil B2), Klosterstraße 68, 12249 Berlin
 latitude: 52.481937
 longitude: 13.390688
 altitude: 78
-community: berlin
+community: true
 
 hosts:
   - hostname: flughafen-core

--- a/locations/forcki.yml
+++ b/locations/forcki.yml
@@ -5,7 +5,7 @@ location_nice: Forckenbeckplatz, 10249 Berlin
 latitude: 52.519112973573066
 longitude: 13.462383908075621
 altitude: 60
-community: berlin
+community: true
 
 hosts:
   - hostname: forcki-core

--- a/locations/habersaath.yml
+++ b/locations/habersaath.yml
@@ -4,7 +4,7 @@ location: habersaath
 location_nice: Leerstand Hab-ich-saath
 latitude: 52.53207188797019
 longitude: 13.378598767421284
-community: berlin
+community: true
 
 
 role: ap

--- a/locations/hdk-0.yml
+++ b/locations/hdk-0.yml
@@ -3,7 +3,7 @@ location: hdk-0
 location_nice: Heidekampgraben 0
 latitude: 52.478098463
 longitude: 13.47196341
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-0

--- a/locations/hdk-10.yml
+++ b/locations/hdk-10.yml
@@ -3,7 +3,7 @@ location: hdk-10
 location_nice: Heidekampgraben 10
 latitude: 52.478023315
 longitude: 13.47272515
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-10

--- a/locations/hdk-13.yml
+++ b/locations/hdk-13.yml
@@ -3,7 +3,7 @@ location: hdk-13
 location_nice: Heidekampgraben 13
 latitude: 52.478238955
 longitude: 13.47269833
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-13

--- a/locations/hdk-14.yml
+++ b/locations/hdk-14.yml
@@ -3,7 +3,7 @@ location: hdk-14
 location_nice: Heidekampgraben 14
 latitude: 52.478343508
 longitude: 13.47264469
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-14

--- a/locations/hdk-15.yml
+++ b/locations/hdk-15.yml
@@ -3,7 +3,7 @@ location: hdk-15
 location_nice: Heidekampgraben 15
 latitude: 52.478189946
 longitude: 13.4725374
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-15

--- a/locations/hdk-17.yml
+++ b/locations/hdk-17.yml
@@ -3,7 +3,7 @@ location: hdk-17
 location_nice: Heidekampgraben 17
 latitude: 52.478029850
 longitude: 13.47230673
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-17

--- a/locations/hdk-2.yml
+++ b/locations/hdk-2.yml
@@ -3,7 +3,7 @@ location: hdk-2
 location_nice: Heidekampgraben 2
 latitude: 52.477382923
 longitude: 13.4715879
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-2

--- a/locations/hdk-23.yml
+++ b/locations/hdk-23.yml
@@ -3,7 +3,7 @@ location: hdk-23
 location_nice: Heidekampgraben 23
 latitude: 52.477696586
 longitude: 13.47115874
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-23

--- a/locations/hdk-24.yml
+++ b/locations/hdk-24.yml
@@ -3,7 +3,7 @@ location: hdk-24
 location_nice: Heidekampgraben 24
 latitude: 52.477820743
 longitude: 13.47099781
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-24

--- a/locations/hdk-25.yml
+++ b/locations/hdk-25.yml
@@ -3,7 +3,7 @@ location: hdk-25
 location_nice: Heidekampgraben 25
 latitude: 52.478010246
 longitude: 13.4710139
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-25

--- a/locations/hdk-27.yml
+++ b/locations/hdk-27.yml
@@ -3,7 +3,7 @@ location: hdk-27
 location_nice: Heidekampgraben 27
 latitude: 52.477873020
 longitude: 13.47134113
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-27

--- a/locations/hdk-30.yml
+++ b/locations/hdk-30.yml
@@ -4,7 +4,7 @@ location_nice: Heidekampgraben 30
 latitude: 52.477810941
 longitude: 13.4718132
 
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-30

--- a/locations/hdk-35.yml
+++ b/locations/hdk-35.yml
@@ -3,7 +3,7 @@ location: hdk-35
 location_nice: Heidekampgraben 35
 latitude: 52.478176877
 longitude: 13.47209752
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-35

--- a/locations/hdk-36.yml
+++ b/locations/hdk-36.yml
@@ -3,7 +3,7 @@ location: hdk-36
 location_nice: Heidekampgraben 36
 latitude: 52.478229154
 longitude: 13.47227454
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-36

--- a/locations/hdk-38.yml
+++ b/locations/hdk-38.yml
@@ -3,7 +3,7 @@ location: hdk-38
 location_nice: Heidekampgraben 38
 latitude: 52.478457862
 longitude: 13.47247303
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-38

--- a/locations/hdk-39.yml
+++ b/locations/hdk-39.yml
@@ -3,7 +3,7 @@ location: hdk-39
 location_nice: Heidekampgraben 39
 latitude: 52.478526474
 longitude: 13.47233355
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-39

--- a/locations/hdk-4.yml
+++ b/locations/hdk-4.yml
@@ -3,7 +3,7 @@ location: hdk-4
 location_nice: Heidekampgraben 4
 latitude: 52.477529953
 longitude: 13.47186685
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-4

--- a/locations/hdk-42.yml
+++ b/locations/hdk-42.yml
@@ -3,7 +3,7 @@ location: hdk-42
 location_nice: Heidekampgraben 42
 latitude: 52.478823792
 longitude: 13.47182393
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-42

--- a/locations/hdk-47a.yml
+++ b/locations/hdk-47a.yml
@@ -3,7 +3,7 @@ location: hdk-47a
 location_nice: Heidekampgraben 47a
 latitude: 52.478732310
 longitude: 13.47133577
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-47a

--- a/locations/hdk-48.yml
+++ b/locations/hdk-48.yml
@@ -4,7 +4,7 @@ location_nice: Heidekampgraben 48
 latitude: 52.478928343
 longitude: 13.47121239
 
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-48

--- a/locations/hdk-53.yml
+++ b/locations/hdk-53.yml
@@ -3,7 +3,7 @@ location: hdk-53
 location_nice: Heidekampgraben 53
 latitude: 52.478392517
 longitude: 13.47215653
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-53

--- a/locations/hdk-54.yml
+++ b/locations/hdk-54.yml
@@ -3,7 +3,7 @@ location: hdk-54
 location_nice: Heidekampgraben 54
 latitude: 52.478307568
 longitude: 13.47185612
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-54

--- a/locations/hdk-59.yml
+++ b/locations/hdk-59.yml
@@ -3,7 +3,7 @@ location: hdk-59
 location_nice: Heidekampgraben 59
 latitude: 52.478542810
 longitude: 13.47187758
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-59

--- a/locations/hdk-6.yml
+++ b/locations/hdk-6.yml
@@ -3,7 +3,7 @@ location: hdk-6
 location_nice: Heidekampgraben 6
 latitude: 52.477670447
 longitude: 13.47208679
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-6

--- a/locations/hdk-61.yml
+++ b/locations/hdk-61.yml
@@ -3,7 +3,7 @@ location: hdk-61
 location_nice: Heidekampgraben 61
 latitude: 52.478555879
 longitude: 13.47143233
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-61

--- a/locations/hdk-62.yml
+++ b/locations/hdk-62.yml
@@ -3,7 +3,7 @@ location: hdk-62
 location_nice: Heidekampgraben 62
 latitude: 52.478572215
 longitude: 13.47116947
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-62

--- a/locations/hdk-64.yml
+++ b/locations/hdk-64.yml
@@ -3,7 +3,7 @@ location: hdk-64
 location_nice: Heidekampgraben 64
 latitude: 52.478245490
 longitude: 13.47081542
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-64

--- a/locations/hdk-66b.yml
+++ b/locations/hdk-66b.yml
@@ -3,7 +3,7 @@ location: hdk-66b
 location_nice: Heidekampgraben 66b
 latitude: 52.478026583
 longitude: 13.47064376
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-66b

--- a/locations/hdk-72.yml
+++ b/locations/hdk-72.yml
@@ -3,7 +3,7 @@ location: hdk-72
 location_nice: Heidekampgraben 72
 latitude: 52.478611422
 longitude: 13.47092807
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-72

--- a/locations/hdk-73.yml
+++ b/locations/hdk-73.yml
@@ -3,7 +3,7 @@ location: hdk-73
 location_nice: Heidekampgraben 73
 latitude: 52.478794387
 longitude: 13.47088516
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-73

--- a/locations/hdk-76.yml
+++ b/locations/hdk-76.yml
@@ -3,7 +3,7 @@ location: hdk-76
 location_nice: Heidekampgraben 76
 latitude: 52.478601621
 longitude: 13.47041845
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-76

--- a/locations/hdk-78a.yml
+++ b/locations/hdk-78a.yml
@@ -3,7 +3,7 @@ location: hdk-78a
 location_nice: Heidekampgraben 87a
 latitude: 52.478467664
 longitude: 13.47016096
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-78a

--- a/locations/hdk-79.yml
+++ b/locations/hdk-79.yml
@@ -3,7 +3,7 @@ location: hdk-79
 location_nice: Heidekampgraben 79
 latitude: 52.478376180
 longitude: 13.47003222
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-79

--- a/locations/hdk-8.yml
+++ b/locations/hdk-8.yml
@@ -3,7 +3,7 @@ location: hdk-8
 location_nice: Heidekampgraben 8
 latitude: 52.477788070
 longitude: 13.47240329
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-8

--- a/locations/hdk-80.yml
+++ b/locations/hdk-80.yml
@@ -3,7 +3,7 @@ location: hdk-80
 location_nice: Heidekampgraben 80
 latitude: 52.479571980
 longitude: 13.47096562
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-80

--- a/locations/hdk-82.yml
+++ b/locations/hdk-82.yml
@@ -3,7 +3,7 @@ location: hdk-82
 location_nice: Heidekampgraben 82
 latitude: 52.479186453
 longitude: 13.47159863
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-82

--- a/locations/hdk-83.yml
+++ b/locations/hdk-83.yml
@@ -3,7 +3,7 @@ location: hdk-83
 location_nice: Heidekampgraben 83
 latitude: 52.479019825
 longitude: 13.47195804
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-83

--- a/locations/hdk-85b.yml
+++ b/locations/hdk-85b.yml
@@ -3,7 +3,7 @@ location: hdk-85b
 location_nice: Heidekampgraben 85b
 latitude: 52.478699638
 longitude: 13.47232282
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-85b

--- a/locations/hdk-88m.yml
+++ b/locations/hdk-88m.yml
@@ -3,7 +3,7 @@ location: hdk-88m
 location_nice: Heidekampgraben 88m
 latitude: 52.478186679
 longitude: 13.47312212
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-88m

--- a/locations/hdk-9.yml
+++ b/locations/hdk-9.yml
@@ -3,7 +3,7 @@ location: hdk-9
 location_nice: Heidekampgraben 9
 latitude: 52.477892624
 longitude: 13.47258568
-community: berlin
+community: true
 
 hosts:
   - hostname: hdk-9

--- a/locations/igh-ev.yml
+++ b/locations/igh-ev.yml
@@ -1,7 +1,7 @@
 ---
 
 location: igh-ev
-location_nice: Selchower Straße 22, 12049 Berlin
+location_nice: Selchower Strasse 22, 12049 Berlin
 latitude: 52.47836105779351
 longitude: 13.420856025248085
 altitude: 80
@@ -17,7 +17,8 @@ hosts:
 
   - hostname: igh-ev-ap1 # Unifi AC Pro
     role: ap
-    model: ubnt_unifiac_mesh
+    model: "ubnt_unifiac-pro"
+    wireless_profile: freifunk_default
 
 snmp_devices:
   - hostname: igh-ev-rhnk # Ubiquiti PowerBeam 5AC 300 ISO
@@ -64,6 +65,7 @@ networks:
     prefix: 10.31.191.192/29
     gateway: 1
     dns: 1
+    ntp: 1
     ipv6_subprefix: 0
     assignments:
       igh-ev-core: 1 # 10.31.191.193

--- a/locations/j41.yml
+++ b/locations/j41.yml
@@ -4,7 +4,7 @@ location_nice: Jessnerstraße 41, 10247 Berlin
 latitude: 52.51047588
 longitude: 13.47179912
 altitude: 58
-community: berlin
+community: true
 
 hosts:
   - hostname: j41-core

--- a/locations/klunker.yml
+++ b/locations/klunker.yml
@@ -4,7 +4,7 @@ location_nice: Klunkerkranich
 latitude: 52.4819617
 longitude: 13.4330485
 altitude: 63
-community: berlin
+community: true
 
 hosts:
   - hostname: klunker-core

--- a/locations/koepi.yml
+++ b/locations/koepi.yml
@@ -5,7 +5,7 @@ location_nice: koepi, Köpenicker Straße 137, 10179 Berlin
 latitude: 52.507668
 longitude: 13.426087
 altitude: 52
-community: berlin
+community: true
 
 hosts:
   - hostname: koepi-core

--- a/locations/kotti.yml
+++ b/locations/kotti.yml
@@ -6,7 +6,7 @@ latitude: 52.49943
 longitude: 13.41860
 altitude: 41
 height: 13
-community: berlin
+community: true
 
 hosts:
   - hostname: kotti-core

--- a/locations/l105.yml
+++ b/locations/l105.yml
@@ -4,7 +4,7 @@ location_nice: Lützowstraße 105, 10785 Berlin
 latitude: 52.502040
 longitude: 13.369420
 altitude: 62
-community: berlin
+community: true
 
 local_asn: 65023
 peer_asn: 44194

--- a/locations/mahalle.yml
+++ b/locations/mahalle.yml
@@ -5,7 +5,7 @@ latitude: 52.50099
 longitude: 13.42842
 altitude: 31
 height: 2
-community: berlin
+community: true
 
 hosts:
   - hostname: mahalle-core

--- a/locations/mela.yml
+++ b/locations/mela.yml
@@ -5,7 +5,7 @@ latitude: 52.521306576109
 longitude: 13.188832104206
 altitude: 60
 height: 24
-community: berlin
+community: true
 
 hosts:
   - hostname: mela-core

--- a/locations/mlk-nk.yml
+++ b/locations/mlk-nk.yml
@@ -5,7 +5,7 @@ location_nice: Martin-Luther-Kirche Neukölln
 latitude: 52.484310005530894
 longitude: 13.43617358853226
 altitude: 64
-community: berlin
+community: true
 
 hosts:
   - hostname: mlk-nk-core

--- a/locations/ohlauer.yml
+++ b/locations/ohlauer.yml
@@ -5,7 +5,7 @@ location_nice: Ohlauer
 latitude: 52.49378703855491
 longitude: 13.42969238683751
 altitude: 55
-community: berlin
+community: true
 
 local_asn: 44194
 peer_asn: 5405

--- a/locations/parzelle17-fritz.yml
+++ b/locations/parzelle17-fritz.yml
@@ -3,7 +3,7 @@ location: parzelle17-fritz
 location_nice: Parzelle 17
 latitude: 52.478675
 longitude: 13.471268
-community: berlin
+community: true
 
 dns_servers:
   # quad9

--- a/locations/philmel.yml
+++ b/locations/philmel.yml
@@ -4,7 +4,7 @@ location_nice: Philipp-Melanchthon-Kirche, Kranoldstraße 16, 12051 Berlin
 latitude: 52.465881
 longitude: 13.434112
 altitude: 83
-community: berlin
+community: true
 
 hosts:
   - hostname: philmel-core

--- a/locations/rauchhaus.yml
+++ b/locations/rauchhaus.yml
@@ -5,7 +5,7 @@ location_nice: rauchhaus
 latitude: 52.50481
 longitude: 13.42436
 altitude: 47
-community: berlin
+community: true
 
 hosts:
   - hostname: rauchhaus-core

--- a/locations/rhnk.yml
+++ b/locations/rhnk.yml
@@ -4,7 +4,7 @@ location_nice: "Rathaus Neukölln, Karl-Marx-Straße 83, 12043 Berlin"
 latitude: 52.481380
 longitude: 13.435078
 altitude: 90
-community: berlin
+community: true
 
 hosts:
   # Lenovo 10T8S00S00 / Thinkcentre M720q, i5-8500T, 1x16 GB RAM, 256 GB NVMe

--- a/locations/rhxb.yml
+++ b/locations/rhxb.yml
@@ -5,7 +5,7 @@ location_nice: Rathaus Kreuzberg
 latitude: 52.493778
 longitude: 13.385290
 altitude: 74
-community: berlin
+community: true
 
 hosts:
   - hostname: rhxb-core

--- a/locations/rigaer78.yml
+++ b/locations/rigaer78.yml
@@ -4,7 +4,7 @@ location_nice: Rigaerstraße 78
 latitude: 52.516646
 longitude: 13.464282
 altitude: 56
-community: berlin
+community: true
 
 snmp_devices:
   - hostname: rigaer78-sama

--- a/locations/rigaer83.yml
+++ b/locations/rigaer83.yml
@@ -5,7 +5,7 @@ location_nice: Rigaerstraße 83
 latitude: 52.517060
 longitude: 13.461940
 altitude: 58
-community: berlin
+community: true
 
 hosts:
   - hostname: rigaer83-core

--- a/locations/rio.yml
+++ b/locations/rio.yml
@@ -5,7 +5,7 @@ location_nice: Rio-Reiser-Platz
 latitude: 52.500355
 longitude: 13.423608
 altitude: 46
-community: berlin
+community: true
 
 hosts:
   - hostname: rio-core

--- a/locations/saarbruecker.yml
+++ b/locations/saarbruecker.yml
@@ -3,7 +3,7 @@ location: saarbruecker
 location_nice: Saarbrücker
 latitude: 52.5283930134242
 longitude: 13.41561550087894
-community: berlin
+community: true
 
 local_asn: 44194
 peer_asn: 25291

--- a/locations/sama.yml
+++ b/locations/sama.yml
@@ -4,7 +4,7 @@ location_nice: "Samariterkirche, Samariterstr. 27, 10247 Berlin"
 latitude: 52.518044835152963
 longitude: 13.466172516345976
 altitude: 77
-community: berlin
+community: true
 
 hosts:
   - hostname: sama-core

--- a/locations/scharni.yml
+++ b/locations/scharni.yml
@@ -4,7 +4,7 @@ location_nice: Scharni
 latitude: 52.512702825706896
 longitude: 13.464007297614232
 altitude: 52
-community: berlin
+community: true
 
 hosts:
   - hostname: scharni-core

--- a/locations/schleidenplatz.yml
+++ b/locations/schleidenplatz.yml
@@ -4,7 +4,7 @@ location: schleidenplatz
 location_nice: schleidenplatz
 latitude: 52.515432
 longitude: 13.473224
-community: berlin
+community: true
 
 hosts:
   - hostname: schleidenplatz-core

--- a/locations/schreiner.yml
+++ b/locations/schreiner.yml
@@ -4,7 +4,7 @@ location: schreiner
 location_nice: Schreiner27
 latitude: 52.51630220759532
 longitude: 13.470166
-community: berlin
+community: true
 
 hosts:
   - hostname: schreiner-core

--- a/locations/simeon.yml
+++ b/locations/simeon.yml
@@ -5,7 +5,7 @@ location_nice: St.-Simeon-Kirche, Wassertorstraße 21, Berlin
 latitude: 52.500582
 longitude: 13.406656
 altitude: 105
-community: berlin
+community: true
 
 hosts:
   - hostname: simeon-core

--- a/locations/strom.yml
+++ b/locations/strom.yml
@@ -5,7 +5,7 @@ location_nice: Stromstraße 2A
 latitude: 52.523268237
 longitude: 13.342632651
 altitude: 55
-community: berlin
+community: true
 
 local_asn: 65023
 peer_asn: 44194

--- a/locations/teufelsberg.yml
+++ b/locations/teufelsberg.yml
@@ -5,7 +5,7 @@ location_nice: Teufelsberg, Teufelsseechaussee 10, 14193 Berlin
 latitude: 52.49800
 longitude: 13.24052
 altitude: 151
-community: berlin
+community: true
 
 # ROUTER: 10.31.213.0/24
 # --MGMT: 10.31.213.0/26

--- a/locations/teufelssecurity.yml
+++ b/locations/teufelssecurity.yml
@@ -5,7 +5,7 @@ location_nice: Teufelsberg Wachhäuschen
 latitude: 52.49649
 longitude: 13.23970
 altitude: 99
-community: berlin
+community: true
 
 # ROUTER: 10.31.243.64/26
 # --MGMT: 10.31.243.64/28

--- a/locations/walde.yml
+++ b/locations/walde.yml
@@ -5,7 +5,7 @@ location_nice: Waldemarstrasse 103
 latitude: 52.501329204
 longitude: 13.427798152
 altitude: 47
-community: berlin
+community: true
 
 hosts:
   - hostname: walde-core

--- a/locations/wuhli.yml
+++ b/locations/wuhli.yml
@@ -6,7 +6,7 @@ latitude: 52.465406
 longitude: 13.536190
 altitude: 36
 height: 7
-community: berlin
+community: true
 
 hosts:
   - hostname: wuhli-core

--- a/locations/wuhlipunks.yml
+++ b/locations/wuhlipunks.yml
@@ -6,7 +6,7 @@ latitude: 52.466118
 longitude: 13.537581
 altitude: 32
 height: 5
-community: berlin
+community: true
 
 hosts:
   - hostname: wuhlipunks-core

--- a/locations/xdorf.yml
+++ b/locations/xdorf.yml
@@ -5,7 +5,7 @@ location_nice: xdorf
 latitude: 52.504855
 longitude: 13.424628
 altitude: 40
-community: berlin
+community: true
 
 hosts:
   - hostname: xdorf-core

--- a/locations/zwingli.yml
+++ b/locations/zwingli.yml
@@ -4,7 +4,7 @@ location_nice: Zwinglikirche, Rudolfstraße 14, 10245 Berlin
 latitude: 52.5035417
 longitude: 13.4547472
 altitude: 77
-community: berlin
+community: true
 
 hosts:
   - hostname: zwingli-core

--- a/roles/cfg_openwrt/templates/common/config/freifunk.j2
+++ b/roles/cfg_openwrt/templates/common/config/freifunk.j2
@@ -1,16 +1,25 @@
 config public 'contact'
-{% if contact_name is defined %}
+{% if community | default(false) is true and contact_name is undefined %}
+	option name 'Freifunk Engenieering Task Force'
+{% elif contact_name is defined %}
 	option name '{{ contact_name }}'
 {% endif %}
-{% if contact_nickname is defined %}
+{% if community | default(false) is true and contact_nickname is undefined %}
+	option nickname 'FETF'
+{% elif contact_nickname is defined %}
 	option nickname '{{ contact_nickname }}'
 {% endif %}
-{% for contact in contacts | mandatory('Please add at least one contact. Fellow Freifunkas need to be able to contact you in case they want to mesh with you!') %}
+{% if contact_email is defined %}
+	{{ contact_email_depr | mandatory('The option "contact_email" in location/general.yml is deprecated. Please rename that flag to "contacts" and make sure to transform it into to a list.') }}
+{% elif community | default(false) is true and contacts is undefined %}
+	option mail 'info+{{ location }}@berlin.freifunk.net'
+{% else %}
+{% for contact in contacts | mandatory('Please add at least one contact information via the contacts-flag in location/general.yml. Fellow Freifunkas need to be able to contact you in case they want to mesh with you!') %}
 	list contact '{{ contact }}'
 {% endfor %}
+{% endif %}
 	option location '{{ location_nice }}'
 
-{# set defaults to maintain current functionality for transition phase #}
 config public 'community'
-    option homepage '{{ homepage|default('https://freifunk.net') }}'
-    option name '{{ community|default('berlin') }}'
+	option homepage 'http://freifunk.net'
+	option name 'berlin'


### PR DESCRIPTION
Adds model_ubnt_unifiac_pro and updates location igh-ev to use it.