### PR TITLE
funkpilz: init location

### DIFF
--- a/locations/funkpilz.yml
+++ b/locations/funkpilz.yml
@@ -1,0 +1,77 @@
+---
+location: funkpilz
+location_nice: Kleingartenkolonie Weidenbaum, Straße 70 Nr. 8+10, 13627 Berlin
+latitude: 52.542367819836
+longitude: 13.303652107716
+altitude: 27
+height: 2
+contact_nickname: "wbaum"
+contacts:
+  - "loeten@buerotiger.de"
+  - "@wbaum:matrix.org"
+
+hosts:
+  - hostname: funkpilz
+    role: corerouter
+    model: "genexis_pulse-ex400"
+    wireless_profile: freifunk_default
+
+ipv6_prefix: "2001:bf7:800:2700::/56"
+
+# got following prefixes:
+# Router: 10.248.95.64/27
+# --MGMT: 10.248.95.64/29
+# --MESH: 10.248.95.72/29
+# --DHCP: 10.248.95.80/28
+
+networks:
+  # 802.11s Links
+  # MESH - 5 GHz 802.11s
+  - vid: 20
+    role: mesh
+    name: mesh_5g
+    prefix: 10.248.95.72/32
+    ipv6_subprefix: -20
+    mesh_ap: funkpilz
+    mesh_radio: 11a_standard
+    mesh_iface: mesh
+
+  # MESH - 2.4 GHz 802.11s
+  - vid: 21
+    role: mesh
+    name: mesh_2g
+    prefix: 10.248.95.73/32
+    ipv6_subprefix: -21
+    # make mesh_metric for 2.4 GHz worse than 5 GHz
+    mesh_metric_lqm: ["default 0.5"]
+    mesh_ap: funkpilz
+    mesh_radio: 11g_standard
+    mesh_iface: mesh
+
+  # DHCP
+  - vid: 40
+    role: dhcp
+    prefix: 10.248.95.80/28
+    ipv6_subprefix: 0
+    inbound_filtering: true
+    enforce_client_isolation: true
+    assignments:
+      funkpilz: 1
+
+  # MGMT
+  - vid: 42
+    role: mgmt
+    prefix: 10.248.95.64/29
+    gateway: 1
+    dns: 1
+    ipv6_subprefix: 1
+    assignments:
+      funkpilz: 1 # 10.248.95.65
+
+# AP-id, wifi-channel, bandwidth, txpower
+location__channel_assignments_11a_standard__to_merge:
+  funkpilz: 36-40
+
+# AP-id, wifi-channel, bandwidth, txpower
+location__channel_assignments_11g_standard__to_merge:
+  funkpilz: 13-20


### PR DESCRIPTION
This location gets converted from Falter to bbb-configs and the old outdated device will be replaced. This PR should be merged once the new device is installed.

- [x] prepare device
- [ ] install device