### PR TITLE
hway: update to OpenWrt 25.12 & revert bird3

### DIFF
--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -26,6 +26,7 @@ hosts:
     role: corerouter
     int_port: eth0
     model: x86-64
+    openwrt_version: 25.12-SNAPSHOT
     host__packages__to_merge:
       - kmod-mlx5-core
     host__rclocal__to_merge:
@@ -47,7 +48,6 @@ hosts:
     role: ap
     wireless_profile: hway
     model: cudy_ap3000outdoor-v1
-    openwrt_version: 24.10-SNAPSHOT
 
 snmp_devices:
   - hostname: hway-kiehlufer


### PR DESCRIPTION
(haven't actually tested on that cudy_ap3000-outdoor-v1 yet, it's not currently running)