### PR TITLE
model: avm-fritzbox-4040: update to OpenWrt 25.12

### DIFF
--- a/group_vars/model_avm_fritzbox_4040.yml
+++ b/group_vars/model_avm_fritzbox_4040.yml
@@ -2,6 +2,7 @@
 target: ipq40xx/generic
 brand_nice: AVM
 model_nice: FRITZ!Box 4040
+openwrt_version: 25.12-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"


### PR DESCRIPTION
Update to newest OpenWrt Release.