### PR TITLE
ansible: switch to merge_variables lookup filter

### DIFF
--- a/action_plugins/merge_vars.py
+++ b/action_plugins/merge_vars.py
@@ -1,1 +1,0 @@
-from ansible_merge_vars import ActionModule

--- a/inventory/README.md
+++ b/inventory/README.md
@@ -28,7 +28,7 @@ There are five (now four) stages that construct our inventory data:
 4. Keyed groups, pt. 2
   - Same, but handles `target` and `openwrt_version`.
 5. Merge vars
-  - Handled by Ansible's "merge_vars" action plugin.
+  - Handled by Ansible's `merge_variables` lookup filter.
   - All hostvars construction so far was only able to overwrite properties,
     but in some cases we need to merge with the existing property.
   - For specific properties, a "merge var" can be set:
@@ -38,5 +38,6 @@ There are five (now four) stages that construct our inventory data:
     scope we're currently in, e.g. `location__packages__to_merge`.
   - These merge vars are merged together into one
     before any templates or tasks make use of hostvars.
-  - Handles `ssh_keys`, `packages`, `sysctl`, `rclocal`,
-    `disabled_services`, `wireless_profiles`, `channel_assignments_*`.
+  - Handles `ssh_keys`, `packages`, `sysctl`, `rclocal`, `disabled_services`,
+    `wireless_profiles`, `channel_assignments_11a_standard`,
+    and `channel_assignments_11g_standard`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ansible == 12.0.0
 ansible-lint == 25.9.0
-ansible_merge_vars == 5.0.0 # We might not need it any longer https://github.com/leapfrogonline/ansible-merge-vars
 jmespath == 1.0.1
 netaddr == 1.3.0
 yamllint == 1.37.1

--- a/roles/cfg_openwrt/tasks/merge_vars.yml
+++ b/roles/cfg_openwrt/tasks/merge_vars.yml
@@ -1,44 +1,20 @@
 ---
-- name: Merge packages variable
-  merge_vars:
-    suffix_to_merge: __packages__to_merge
-    merged_var_name: packages
-    expected_type: list
 
-- name: Merge disabled_services variable
-  merge_vars:
-    suffix_to_merge: __disabled_services__to_merge
-    merged_var_name: disabled_services
-    expected_type: list
+- name: Merge vars
+  ansible.builtin.set_fact:
+    "{{ item.key }}": "{{ lookup('community.general.merge_variables', '__' + item.key + '__to_merge', pattern_type='suffix', initial_value=item.value) }}"
+  loop: "{{ the_vars | dict2items }}"
+  vars:
+    the_vars:
+      packages: []
+      disabled_services: []
+      wireless_profiles: []
+      sysctl: {}
+      rclocal: []
+      channel_assignments_11a_standard: {}
+      channel_assignments_11g_standard: {}
 
-- name: Merge wireless_profiles variable
-  merge_vars:
-    suffix_to_merge: __wireless_profiles__to_merge
-    merged_var_name: wireless_profiles
-    expected_type: list
-
-- name: Merge ssh_keys variable
-  merge_vars:
-    suffix_to_merge: __ssh_keys__to_merge
-    merged_var_name: ssh_keys
-    expected_type: list
+- name: Merge ssh_keys
+  ansible.builtin.set_fact:
+    "ssh_keys": "{{ lookup('community.general.merge_variables', '__ssh_keys__to_merge', pattern_type='suffix', initial_value=[]) }}"
   when: ssh_keys is undefined
-
-- name: Merge sysctl variable
-  merge_vars:
-    suffix_to_merge: __sysctl__to_merge
-    merged_var_name: sysctl
-    expected_type: dict
-
-- name: Merge rclocal variable
-  merge_vars:
-    suffix_to_merge: __rclocal__to_merge
-    merged_var_name: rclocal
-    expected_type: list
-
-- name: "Merge channel_assignments variables"
-  merge_vars:
-    suffix_to_merge: "__{{ item.split('__')[1] + '__to_merge' }}"
-    merged_var_name: "{{ item.split('__')[1] }}"
-    expected_type: dict
-  loop: "{{ hostvars[inventory_hostname] | select('match', '.*__channel_assignments_.*') }}"


### PR DESCRIPTION
This new filter is part of the ansible.community.general collection since the collection's version 6.5.0.

Two advantages:

1. No more need for an action plugin.

2. We get more control over the key names, while the old action plugin only allowed for suffix to be configured. We could now do a full regexp and achieve shorter key names such as `packages__bird` instead of the unwieldy `bird__packages__to_merge`.

I verified that the configs for all hosts build the same as before.