### PR TITLE
imageprofile: invert the conditional_packages logic

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -12,18 +12,19 @@ imagebuilder_filename: "openwrt-imagebuilder-{{ openwrt_version }}-{{ target | r
 imagebuilder: "{{ openwrt_mirror }}/{{ openwrt_base }}/targets/{{ target }}/{{ imagebuilder_filename }}"
 feed: "src/gz openwrt_falter https://firmware.berlin.freifunk.net/feed/{{ feed_version }}/packages/__INSTR_SET__/falter"
 
+# The packages list is spread over a number of lists for two reasons:
+# 1. Individual locations want to override particular packages
+#    without dealing with the complete packages list.
+# 2. We want to omit certain packages based on device properties or config,
+#    e.g. devices with low ram / low flash, or with or without tunspace uplink.
+
 all__packages__to_merge:
-  - ethtool
   - ip6tables-nft # Its not pulled in by default anymore bc fw4
   - iptables-nft
-  - iperf3
-  - iwinfo
   - ip
   - kmod-nft-bridge
   - mtr
   - nftables
-  - tcpdump-mini
-  - vnstat
   - -ppp
   - -ppp-mod-pppoe
 
@@ -46,5 +47,47 @@ all_collectd__packages__to_merge:
   - collectd-mod-ping
   - collectd-mod-uptime
 
-all__disabled_services__to_merge:
-  - "olsrd6"
+multicore__packages__to_merge:
+  - irqbalance
+
+# Will be removed unless wifi_roaming
+dawn__packages__to_merge:
+  - dawn
+  - luci-app-dawn
+  - umdns
+
+# Will be removed unless it's a device with DSA switch driver
+dsa__packages__to_merge:
+  - ip-bridge
+
+zram__packages__to_merge:
+  - zram-swap
+
+notlow__packages__to_merge:
+  - ethtool
+  - iperf3
+  - iwinfo
+  - libiwinfo-lua
+  - collectd-mod-iwinfo
+  - tcpdump
+  - vnstat
+
+low__packages__to_merge:
+  - tcpdump-mini
+  - -opkg
+  - -kmod-ipt-core
+  - -kmod-ipt-offload
+  - -kmod-nf-ipt
+  - -kmod-nls-base
+  - -kmod-phy-ath79-usb
+  - -kmod-usb-core
+  - -kmod-usb-ehci
+  - -kmod-usb-ohci
+  - -kmod-usb2
+
+qos__packages__to_merge:
+  - qos-scripts
+
+# This will be overridden unless low_mem
+low__disabled_services__to_merge:
+  - uhttpd

--- a/group_vars/role_corerouter/imageprofile.yml
+++ b/group_vars/role_corerouter/imageprofile.yml
@@ -29,3 +29,18 @@ collectd__packages__to_merge:
 bird__packages__to_merge:
   - bird2-babelpatch
   - bird2c
+
+tunnel__packages__to_merge:
+  - tunspace
+  - wireguard-tools
+
+dfs__packages__to_merge:
+  - airos-dfs-reset
+
+util__packages__to_merge:
+  - mosh-server
+  - tmux
+
+# There's no way to install only olsrd without olsrd6
+all__disabled_services__to_merge:
+  - "olsrd6"

--- a/roles/cfg_openwrt/tasks/conditional_packages.yml
+++ b/roles/cfg_openwrt/tasks/conditional_packages.yml
@@ -1,97 +1,70 @@
 ---
-- name: "Add irqbalance if multicore"
-  set_fact:
-    packages: "{{ packages + ['irqbalance'] }}"
-  when:
-    - multicore|default(false)|bool
 
-- name: "Add airos-dfs-reset if configured"
+- name: "Omit irqbalance unless multicore"
   set_fact:
-    packages: "{{ packages + ['airos-dfs-reset'] }}"
+    multicore__packages__to_merge: []
   when:
-    - airos_dfs_reset|default([])|length > 0
-    - role == 'corerouter'
+    - not (multicore | default(false))
 
-- name: "Add Dawn + Luci app for corerouters"
+- name: "Omit airos-dfs-reset unless configured"
   set_fact:
-    packages: "{{ packages + [item] }}"
+    dfs__packages__to_merge: []
   when:
-    - role == 'corerouter' or role == 'ap'
-    - not (low_mem | default(false))
-    - not (low_flash | default(false))
-    - wifi_roaming | default(false)
-  loop:
-    - dawn
-    - luci-app-dawn
-    - umdns
+    - not (airos_dfs_reset | default([]) | count > 1)
 
-- name: "Add tunspace if configured"
+- name: "Omit DAWN unless configured"
   set_fact:
-    packages: "{{ packages + ['tunspace', 'wireguard-tools'] }}"
+    dawn__packages__to_merge: []
   when:
-    - networks is defined
-    - networks | selectattr('role', 'defined') | selectattr('role','equalto','tunnel') | count > 0
-    - role == 'corerouter'
+    - not (wifi_roaming | default(false))
 
-- name: "Add zram-swap on low mem and big flash"
+- name: "Omit tunspace unless configured"
   set_fact:
-    packages: "{{ packages + ['zram-swap'] }}"
+    tunnel__packages__to_merge: []
   when:
-    - low_mem | default(false)
-    - not (low_flash | default(false))
+    - networks is not defined or networks | selectattr('role','equalto','tunnel') | count == 0
 
-- name: "Add debugging-packages on core-routers"
+- name: "Omit zram-swap unless low mem and big flash"
   set_fact:
-    packages: "{{ packages + ['mosh-server', 'tmux'] }}"
+    zram__packages__to_merge: []
   when:
-    - role == 'corerouter'
-    - not (low_mem | default(false))
-    - not (low_flash | default(false))
+    # CONFIG_KERNEL_SWAP is disabled on many low_flash devices (citation needed)
+    - not (low_mem | default(false) and not (low_flash | default(false)))
 
-- name: "Remove or replace packages on low mem and low flash"
+- name: "Omit corerouter utilities if low mem or low flash"
   set_fact:
-    packages: "{{ packages + [item] }}"
+    util__packages__to_merge: []
+  when:
+    - low_mem | default(false) or low_flash | default(false)
+
+- name: "Omit notlow packages if low mem or low flash"
+  set_fact:
+    notlow__packages__to_merge: []
   when: low_mem | default(false) or low_flash | default(false)
-  loop:
-    - -ethtool
-    - -iperf3
-    - -iwinfo
-    - -libiwinfo-lua
-    - -collectd-mod-iwinfo
-    - -kmod-ipt-core
-    - -kmod-ipt-offload
-    - -kmod-nf-ipt
-    - -kmod-nls-base
-    - -kmod-phy-ath79-usb
-    - -kmod-usb-core
-    - -kmod-usb-ehci
-    - -kmod-usb-ohci
-    - -kmod-usb2
-    - -opkg
-    - -tcpdump
-    - tcpdump-mini
-    - -vnstat
 
-- name: "Remove Luci on low mem and low flash"
+- name: "Omit low packages unless low mem or low flash"
   set_fact:
-    packages: "{{ packages + ['-' + item] }}"
+    low__packages__to_merge: []
+  when: not (low_mem | default(false) or low_flash | default(false))
+
+- name: "Omit LuCI if low mem or low flash unless corerouter"
+  set_fact:
+    all_luci_base__packages__to_merge: []
   when: (low_mem | default(false) or low_flash | default(false)) and role != "corerouter"
-  loop: "{{ all_luci_base__packages__to_merge }}"
 
-- name: "Disable uhttpd on low mem"
+- name: "Skip disabling uhttpd unless low mem"
   set_fact:
-    disabled_services: "{{ disabled_services + ['uhttpd'] }}"
-  when: low_mem | default(false)
+    low__disabled_services__to_merge: []
+  when: not (low_mem | default(false))
 
-- name: "Add ip-bridge if dsa target"
+- name: "Omit ip-bridge unless DSA target"
   set_fact:
-    packages: "{{ packages + ['ip-bridge'] }}"
+    dsa__packages__to_merge: []
   when:
-    - dsa_ports is defined
+    - not (dsa_ports is defined)
 
 - name: "Add QOS support if configured"
   set_fact:
-    packages: "{{ packages + ['qos-scripts'] }}"
+    qos__packages__to_merge: []
   when:
-    - networks is defined
-    - networks | selectattr('ingress', 'defined') | count > 0 or networks | selectattr('egress', 'defined') | count > 0
+    - networks is not defined or networks | selectattr('ingress', 'defined') | count == 0 or networks | selectattr('egress', 'defined') | count == 0

--- a/roles/cfg_openwrt/tasks/conditional_packages.yml
+++ b/roles/cfg_openwrt/tasks/conditional_packages.yml
@@ -89,12 +89,6 @@
   when:
     - dsa_ports is defined
 
-- name: "Add poemgr if poemgr target"
-  set_fact:
-    packages: "{{ packages + ['poemgr'] }}"
-  when:
-    - poemgr_ports is defined
-
 - name: "Add QOS support if configured"
   set_fact:
     packages: "{{ packages + ['qos-scripts'] }}"

--- a/roles/cfg_openwrt/tasks/main.yml
+++ b/roles/cfg_openwrt/tasks/main.yml
@@ -68,17 +68,6 @@
     - always
     - config
 
-- name: Add poemgr config if poemgr target
-  template:
-    src: "{{ role_path }}/templates/common/config/poemgr.j2"
-    dest: "{{ configs_dir }}/etc/config/poemgr"
-    mode: "644"
-  when:
-    - poemgr_ports is defined
-  tags:
-    - always
-    - config
-
 - name: "Make sure /lib/firmware is present"
   file:
     dest: "{{ configs_dir }}/lib/firmware/ath10k"

--- a/roles/cfg_openwrt/tasks/main.yml
+++ b/roles/cfg_openwrt/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
-- name: Include tasks for merging variables
+- name: Include tasks for conditional packages
   include_tasks:
-    file: merge_vars.yml
+    file: conditional_packages.yml
     apply:
       tags: always
   tags: always
 
-- name: Include tasks for conditional packages
+- name: Include tasks for merging variables
   include_tasks:
-    file: conditional_packages.yml
+    file: merge_vars.yml
     apply:
       tags: always
   tags: always

--- a/roles/cfg_openwrt/templates/ap/config/poemgr.j2
+++ b/roles/cfg_openwrt/templates/ap/config/poemgr.j2
@@ -1,0 +1,1 @@
+../../common/config/poemgr.j2

--- a/roles/cfg_openwrt/templates/common/config/poemgr.j2
+++ b/roles/cfg_openwrt/templates/common/config/poemgr.j2
@@ -1,12 +1,14 @@
+{% if poemgr_ports is defined %}
 config poemgr 'settings'
         option profile 'usw-flex'
         option disabled '0'
         option power_budget '{{ poemgr_power_budget | default('0') }}'
 
-{% for poe in poemgr_ports | default([]) %}
+{% for poe in poemgr_ports %}
 config port '{{ poe['name'] }}'
         option name '{{ poe['name'] }}'
         option port '{{ poe['port'] }}'
         option disabled '{{ poe['disabled'] }}'
 
 {% endfor %}
+{% endif %}

--- a/roles/cfg_openwrt/templates/corerouter/config/poemgr.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/poemgr.j2
@@ -1,0 +1,1 @@
+../../common/config/poemgr.j2


### PR DESCRIPTION
The goal of this PR is to have all packages, even conditional packages, defined in the imageprofile files. This will prevent future confusion as to why certain packages are included or not included, and where that is defined.

To achieve this, we put all groups of conditional packages into respective new merge_vars variables in the imageprofile files. Then later in conditional_vars.yml we remove these based on the given conditions.

- [ ] Double-check the inversion of the individual conditionals
- [ ] Add more comments