### PR TITLE
saarbruecker: uplink broken, skip static ipv4 default route announcement

### DIFF
--- a/locations/saarbruecker.yml
+++ b/locations/saarbruecker.yml
@@ -37,6 +37,7 @@ snmp_devices:
 ipv6_prefix: 2001:bf7:760:2200::/56
 
 uplink:
+  broken: true
   ifname: eth5
   ipv4: 176.74.57.43/31
   ipv6: 2a04:d480:2001::1/127

--- a/roles/cfg_openwrt/templates/gateway/bird.conf.j2
+++ b/roles/cfg_openwrt/templates/gateway/bird.conf.j2
@@ -77,12 +77,16 @@ protocol pipe pipe_v4_main_to_babel_default {
 {% else %}
   {% set v4_nexthop =  uplink['ipv4'] | ansible.utils.ipaddr('1') | ansible.utils.ipaddr('address') %}
 {%- endif %}
+{% if not uplink.get('broken', false) %}
 
 protocol static static_uplink {
 	ipv4 { table v4_main; };
 	check link;
 	route 0.0.0.0/0 via {{ v4_nexthop }} dev "{{ uplink['ifname'] }}";
 }
+{% else %}
+## Skipping, uplink via {{ v4_nexthop }} is marked broken
+{% endif %}
 
 ##
 ## Babel Section

--- a/roles/cfg_openwrt/templates/gateway/config/olsrd.j2
+++ b/roles/cfg_openwrt/templates/gateway/config/olsrd.j2
@@ -80,6 +80,10 @@ config Hna4
 # Announce default route, its anyways not used for forwarding within BBB
 # We only need it to attract traffic from legacy mesh nodes, until babel
 # takes over in our core network
+{% if not uplink.get('broken', false) %}
 config Hna4
 	option netmask '0.0.0.0'
 	option netaddr '0.0.0.0'
+{% else %}
+# Skipping, uplink is marked broken
+{% endif %}


### PR DESCRIPTION
This isn't pretty, but it is reality. Otherwise saarbruecker-gw blackholes IPv4 traffic.