### PR TITLE
Revert "gateways: make Webinterface unreachable from uplink site"

### DIFF
--- a/roles/cfg_openwrt/templates/gateway/config/firewall.j2
+++ b/roles/cfg_openwrt/templates/gateway/config/firewall.j2
@@ -101,6 +101,13 @@ config rule
 	option target		ACCEPT
 
 config rule
+	option name             "Allow HTTPS"
+	option src		uplink
+	option proto		tcp
+	option dest_port        443
+	option target		ACCEPT
+
+config rule
 	option name             "Allow GRE"
 	option src		uplink
 	option proto		gre


### PR DESCRIPTION
This reverts commit 30a341c7ed997d9c1d1f36ff699742413b5028f4.

We need HTTPS so the gateways can receive tunspace registrations (at /ubus).