### PR TITLE
templates: fix client isolation and accept_ra on untagged VLANs

### DIFF
--- a/roles/cfg_openwrt/templates/common/nftables.conf.j2
+++ b/roles/cfg_openwrt/templates/common/nftables.conf.j2
@@ -1,4 +1,5 @@
 #jinja2: trim_blocks: True, lstrip_blocks: True
+{% import 'libraries/network.j2' as libnetwork with context %}
 #!/usr/sbin/nft -f
 {% set profile = wireless_profiles | selectattr('name', 'equalto', wireless_profile) | list | first -%}
 
@@ -41,7 +42,7 @@ network_ifname_map =
   {% set wifi_ifnames = network_ifname_map | selectattr('network', 'equalto', name) | map(attribute='ifname') %}
   {% if wifi_ifnames|length > 0 %}
     {% set wifi = '{ ' + wifi_ifnames | join(', ') + '}' %}
-    {% set uplink = (('switch0' if dsa_ports is defined else int_port) + '.' + network['vid']|string) if role == 'ap' else '!= ' + wifi %}
+    {% set uplink = libnetwork.getPortIfname(network) if role == 'ap' else '!= ' + wifi %}
     {% if loop.first %}
 define gw = 02:00:00:00:00:01
 define bc = ff:ff:ff:ff:ff:ff

--- a/roles/cfg_openwrt/templates/common/sysctl.conf.j2
+++ b/roles/cfg_openwrt/templates/common/sysctl.conf.j2
@@ -1,4 +1,5 @@
 #jinja2: trim_blocks: True, lstrip_blocks: True
+{% import 'libraries/network.j2' as libnetwork with context %}
 # Defaults are configured in /etc/sysctl.d/* and can be customized in this file
 {% for i in sysctl | default({}) %}
 {{ i }}={{ sysctl[i] }}
@@ -10,7 +11,7 @@ vm.swappiness=100
 
 {% if role == 'ap' %}
   {% for network in networks | selectattr('vid', 'defined') %}
-  {% set port = ('switch0' if dsa_ports is defined else int_port) + '.' + network['vid']|string %}
+  {% set port = libnetwork.getPortIfname(network) %}
   {% if 'ipv6_subprefix' in network and 'assignments' in network and inventory_hostname in network['assignments'] %}
 net.ipv6.conf.{{ port | replace('.', '/') }}.accept_ra=2
   {% endif %}


### PR DESCRIPTION
Client isolation was broken if a DHCP network is untagged:

    /etc/nftables.conf:16:7-13: Error: Interface does not exist
                   iif eth0.40 accept
                       ^^^^^^^

The accept_ra sysctl breaks similarly if the network is untagged.