### PR TITLE
rhnk: adjusting metrics of the bad AK36 link

### DIFF
--- a/locations/rhnk.yml
+++ b/locations/rhnk.yml
@@ -160,7 +160,7 @@ networks:
     role: mesh
     name: mesh_ak36
     prefix: 10.230.3.22/32
-    mesh_metric: 128
+    mesh_metric: 512 # temporarily increase from 128 to 512 until antennas get realigned
     ipv6_subprefix: -22
 
   - vid: 23


### PR DESCRIPTION
This PR introduces a higher metric for the ak36 so we can keep the devices online, but not use them for routing internet traffic.