### PR TITLE
fixup: imagebuilder: bring back __INSTR_SET__ placeholder

### DIFF
--- a/roles/cfg_openwrt/tasks/imagebuilder.yml
+++ b/roles/cfg_openwrt/tasks/imagebuilder.yml
@@ -111,7 +111,7 @@
 - name: Add falter APK feed to image
   lineinfile:
     path: "{{ configs_dir }}/etc/apk/repositories.d/falter.list"
-    line: "{{ feed }}"
+    line: "{{ feed | replace('__INSTR_SET__', instr_set) }}"
     create: true
     mode: "644"
   when: 'uses_apk is defined and feed_version is defined'


### PR DESCRIPTION
Fixes #1515 / e3e8d307abc2bca57b265670316ab5c6e15bd734

The APK config on the running device didn't have `__instr_set__` replaced.