### PR TITLE
qos-scripts: add tag to interface declarations which enable qos

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -282,6 +282,18 @@ qmi:
 ```
 
 
+### bandwith limits
+
+An optional configuration parameter can be added to any non-tunnel interface to limit the bandwitdh available on that interface.  When either `ingress` or `egress` are included in any interface definition, qos-scripts will be installed.  The values for `ingress` and `egress` are in MBit/s.
+
+```yml
+  - vid: 50
+    rold: uplink
+    ingress: 150     # limit downloads to 150MBit/s
+    egress: 50       # limit uploads to 50MBit/s
+```
+
+
 ### ssh-keys
 
 By default the ssh-keys within `all/ssh-keys.yml` will be installed on all hosts. To add additional ssh keys use this format:

--- a/roles/cfg_openwrt/tasks/conditional_packages.yml
+++ b/roles/cfg_openwrt/tasks/conditional_packages.yml
@@ -94,3 +94,10 @@
     packages: "{{ packages + ['poemgr'] }}"
   when:
     - poemgr_ports is defined
+
+- name: "Add QOS support if configured"
+  set_fact:
+    packages: "{{ packages + ['qos-scripts'] }}"
+  when:
+    - networks is defined
+    - networks | selectattr('ingress', 'defined') | count > 0 or networks | selectattr('egress', 'defined') | count > 0

--- a/roles/cfg_openwrt/templates/ap/config/qos.j2
+++ b/roles/cfg_openwrt/templates/ap/config/qos.j2
@@ -1,0 +1,1 @@
+../../common/config/qos.j2

--- a/roles/cfg_openwrt/templates/common/config/qos.j2
+++ b/roles/cfg_openwrt/templates/common/config/qos.j2
@@ -1,0 +1,82 @@
+#jinja2: trim_blocks: True, lstrip_blocks: True
+{% import 'libraries/network.j2' as libnetwork with context %}
+
+{% if 'qos-scripts' in packages %}
+config classify
+	option target 'Priority'
+	option ports '22,53'
+	option comment 'ssh, dns'
+
+config classify
+	option target 'Normal'
+	option proto 'tcp'
+	option ports '20,21,25,80,110,443,993,995'
+	option comment 'ftp, smtp, http(s), imap'
+
+config classify
+	option target 'Express'
+	option ports '5190'
+	option comment 'AOL, iChat, ICQ'
+
+config default
+	option target 'Express'
+	option proto 'udp'
+	option pktsize '-500'
+
+config reclassify
+	option target 'Priority'
+	option proto 'icmp'
+
+config default
+	option target 'Bulk'
+	option portrange '1024-65535'
+
+config classgroup 'Default'
+	option classes 'Priority Express Normal Bulk'
+	option default 'Normal'
+
+config class 'Priority'
+	option packetsize '400'
+	option avgrate '10'
+	option priority '20'
+
+config class 'Priority_down'
+	option packetsize '1000'
+	option avgrate '10'
+
+config class 'Express'
+	option packetsize '1000'
+	option avgrate '50'
+	option priority '10'
+
+config class 'Normal'
+	option packetsize '1500'
+	option packetdelay '100'
+	option avgrate '10'
+	option priority '5'
+
+config class 'Normal_down'
+	option avgrate '20'
+
+config class 'Bulk'
+	option avgrate '1'
+	option packetdelay '200'
+
+  {% for network in networks %}
+    {% if network['ingress'] is defined or network['egress'] is defined %}
+      {% set name = libnetwork.getUciIfname(network) %}
+config interface '{{ name }}'
+	option enabled '1'
+	option classgroup 'Default'
+      {% if network['ingress'] is defined %}
+	option download '{{ network['ingress'] }}000'
+      {% endif %}
+      {% if network['egress'] is defined %}
+	option upload '{{ network['egress'] }}000'
+      {% endif %}
+    {% endif %}
+
+  {% endfor %}
+{% endif %}
+
+

--- a/roles/cfg_openwrt/templates/corerouter/config/qos.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/qos.j2
@@ -1,0 +1,1 @@
+../../common/config/qos.j2

--- a/roles/cfg_openwrt/templates/gateway/config/qos.j2
+++ b/roles/cfg_openwrt/templates/gateway/config/qos.j2
@@ -1,0 +1,1 @@
+../../common/config/qos.j2


### PR DESCRIPTION
On any non-tunnel interface, the options ingress and egress can be added to limit the bandwidth used on that interface.

example to limit download to 200Mbit and upload to 100mbit:
```
  - vid: 50
    role: uplink
    untagged: true
    ingress: 200
    egress: 100
```