### PR TITLE
strom: remove old stuff, replace switch

### DIFF
--- a/locations/strom.yml
+++ b/locations/strom.yml
@@ -30,19 +30,11 @@ hosts:
 snmp_devices:
   - hostname: strom-poe
     address: 10.31.130.66
-    snmp_profile: tplink
+    snmp_profile: swos
 
   - hostname: strom-perleberger
     address: 10.31.130.67
     snmp_profile: af60
-
-  - hostname: strom-tub
-    address: 10.31.130.68
-    snmp_profile: airos_6
-
-  - hostname: strom-no-5ghz
-    address: 10.31.130.69
-    snmp_profile: airos_6
 
 # Router: 10.31.130.64/26 2001:bf7:750:2a00::/56
 # --MGMT: 10.31.130.64/27
@@ -63,13 +55,10 @@ mgmt:
     strom-gw: 1 # .65
     strom-poe: 2 # .66
     strom-perleberger: 3 # .67
-    strom-tub: 4 # .68
-    strom-no-5ghz: 5 # .69
-    # strom-so-5ghz: 6    # .70 (inactive)
 
 # Mesh Network: 10.31.130.96/27
 mesh_links:
-  - name: mesh_tub
+  - name: mesh_local
     ifname: eth0.1308
     ipv4: 10.31.48.1/32
     ipv6: 2001:bf7:750:2a01::/128
@@ -87,11 +76,6 @@ mesh_links:
     # ipv6: 2001:bf7:750:2a03::/128
     mesh_metric: 1024
     ptp: true
-
-  - name: mesh_no
-    ifname: eth0.1399
-    ipv4: 10.31.48.4/32
-    ipv6: 2001:bf7:750:2a04::/128
 
 # OLSR Announce SmartGateway
 sgw: "1000000 1000000"


### PR DESCRIPTION
The `mesh_local` is there to eventually plug a little router in there for local wifi