### PR TITLE
target: install naywatch on mediatek targets

### DIFF
--- a/group_vars/target_mediatek_filogic
+++ b/group_vars/target_mediatek_filogic
@@ -1,3 +1,7 @@
 ---
 
 multicore: true
+
+target__packages__to_merge:
+  # Workaround for apparant mt7530 lockup
+  - naywatch

--- a/group_vars/target_mediatek_mt7622
+++ b/group_vars/target_mediatek_mt7622
@@ -1,3 +1,7 @@
 ---
 
 multicore: true
+
+target__packages__to_merge:
+  # Workaround for apparant mt7530 lockup
+  - naywatch

--- a/group_vars/target_ramips_mt7621
+++ b/group_vars/target_ramips_mt7621
@@ -1,3 +1,7 @@
 ---
 
 multicore: true
+
+target__packages__to_merge:
+  # Workaround for apparant mt7530 lockup
+  - naywatch


### PR DESCRIPTION
On 24.10 and 25.12 we sometimes see some kind of networking lockup on various mediatek devices. The device is just not reachable anymore and needs a reboot. The symptoms are similar to the ipq40xx ethernet lockup a few years ago, although the underlying cause is probably a different one, as ipq40xx is Qualcomm and we're looking at Mediatek here.

Let's do the same workaround: naywatch, which reboots if ethernet neighbors disappear.