### PR TITLE
feat: add wireless uplink functionality

### DIFF
--- a/.github/checks/check-password-file-paths.sh
+++ b/.github/checks/check-password-file-paths.sh
@@ -5,38 +5,38 @@ error_found=0
 
 # If location files are passed as arguments, override the default location_files variable
 if [ "$#" -gt 0 ]; then
-  # Treat location_files as an array to handle multiple arguments
-  location_files=("$@")
+	# Treat location_files as an array to handle multiple arguments
+	location_files=("$@")
 else
-  # Use the default pattern if no arguments are passed
-  location_files=("locations/*.yml")
+	# Use the default pattern if no arguments are passed
+	location_files=("locations/*.yml")
 fi
 
 # Function to check for errors in password file paths
 check() {
-  local yq_query="$1"
-  local file_pattern="$2"
+	local yq_query="$1"
+	local file_pattern="$2"
 
-  # Expand the file pattern to a list of files
-  # shellcheck disable=SC2206
-  files=($file_pattern)
+	# Expand the file pattern to a list of files
+	# shellcheck disable=SC2206
+	files=($file_pattern)
 
-  # Check if any files match the pattern
-  if [ ${#files[@]} -eq 0 ]; then
-    echo "No files matching pattern $file_pattern"
-    return
-  fi
+	# Check if any files match the pattern
+	if [ ${#files[@]} -eq 0 ]; then
+		echo "No files matching pattern $file_pattern"
+		return
+	fi
 
-  # Run the yq command with the expanded list of files
-  pwd_paths=$(yq "$yq_query" "${files[@]}" | grep -v -- '---' | sed 's/["'\'']//g' | sort | uniq)
+	# Run the yq command with the expanded list of files
+	pwd_paths=$(yq "$yq_query" "${files[@]}" | grep -v -- '---' | sed 's/["'\'']//g' | sort | uniq)
 
-  # Iterate over each password path and check if it matches the required pattern
-  for path in $pwd_paths; do
-    if [[ ! "$path" =~ ^file:/[^[:space:]]+ ]]; then
-      echo "Error: Password file path does not match file:/absolute-path/pwd-file and is invalid: $path"
-      error_found=1
-    fi
-  done
+	# Iterate over each password path and check if it matches the required pattern
+	for path in $pwd_paths; do
+		if [[ ! "$path" =~ ^file:/[^[:space:]]+ ]]; then
+			echo "Error: Password file path does not match file:/absolute-path/pwd-file and is invalid: $path"
+			error_found=1
+		fi
+	done
 }
 
 # Check for issues across locations
@@ -45,11 +45,11 @@ echo "Checking ${location_files[*]}"
 # Check for password path issues
 check 'select(.airos_dfs_reset != null) | .airos_dfs_reset[] | select(.password != null) | .password' "${location_files[@]}"
 check 'select(.location__wireless_profiles__to_merge != null) | .location__wireless_profiles__to_merge[] | select(.ifaces != null) | .ifaces[] | select(.key != null) | .key' "${location_files[@]}"
-
+check 'select(.networks != null) | .networks[] | select(.role == "wireless_uplink") | select(.wireless_key != null) | .wireless_key' "${location_files[@]}"
 
 # Exit with a non-zero status code if any errors were found
 if [ "$error_found" -eq 1 ]; then
-  exit 1
+	exit 1
 else
-  echo "No errors found"
+	echo "No errors found"
 fi

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -242,6 +242,39 @@ If there are routes via the tunnels the following command will show a non empty 
 
 If you have multiple uplinks and want one to be preferred, set different link metrics for the different uplinks.
 
+### uplink via wireless
+
+You can configure the router to connect to an existing external WiFi network (e.g., a neighbor's home internet) and use it as an uplink. The wireless interface operates in station mode and is placed inside the tunspace namespace alongside the wireguard tunnel.
+
+```yaml
+  - vid: 51
+    role: wireless_uplink
+    wireless_ssid: "NeighborWiFi"
+    wireless_encryption: psk2             # none, psk2, sae, sae-mixed
+    wireless_key: "file:/root/wireless_uplink_key"  # Required if wireless_encryption is not none
+    wireless_hidden: true                 # Optional: connect to hidden SSID
+    radio: 11g_standard                   # 11g_standard or 11a_standard
+    uplink_ipv4: 192.168.1.42/24          # Optional: DHCP if omitted
+    uplink_gateway: 192.168.1.1           # Required if uplink_ipv4 is set
+
+  - role: tunnel
+    ifname: ts_wg0
+    ...
+```
+
+The wireless uplink works together with tunnel configurations. The wireless interface is moved into the tunspace namespace where the wireguard tunnel also operates.
+
+**Encryption modes:**
+- `none` - Open network (no password)
+- `psk2` - WPA2-PSK
+- `sae` - WPA3 SAE
+- `sae-mixed` - WPA2/WPA3 mixed mode
+
+**Notes:**
+- Only usable on corerouter role
+- The specified radio must be available on the router model
+- Passwords use the `file:/path/to/file` pattern and are replaced on first boot
+
 ### uplink over LTE modem
 
 Many LTE USB sticks work as a so called USB CDC Net device. They emulate a standard ethernet device without any need for further configuration.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -275,6 +275,30 @@ The wireless uplink works together with tunnel configurations. The wireless inte
 - The specified radio must be available on the router model
 - Passwords use the `file:/path/to/file` pattern and are replaced on first boot
 
+**Device Limitations:**
+Not all devices support running multiple APs, 802.11s mesh, and a STA (station) interface simultaneously on the same radio. To check if your device supports this configuration, run:
+
+```
+iw phy phy0 info
+```
+
+Look for the "valid interface combinations" section. Each line describes which combinations of interface types the radio can handle concurrently. For example:
+
+```
+valid interface combinations:
+         * #{ IBSS } <= 1, #{ AP, mesh point } <= 16, #{ managed } <= 19,
+           total <= 19, #channels <= 1, STA/AP BI must match, radar detect widths: { 20 MHz (no HT), 20 MHz, 40 MHz, 80 MHz, 160 MHz }
+```
+
+If your device doesn't support the combination you need, consider:
+- Using a separate radio for the wireless uplink (e.g., 2.4 GHz radio for uplink, 5 GHz for mesh/AP)
+- Using a different device model that supports the required combination
+
+**Channel Limitations:**
+When using a wireless uplink, the radio will use whatever channel is configured on the upstream network and may not be able to mesh with other routers. Our mesh network typically uses channel 13 (2.4 GHz) or channel 36 (5 GHz).
+
+Since most devices are equipped with two radios, you can use one radio for the uplink and the other for meshing with a neighbor. However, depending on the frequency band remaining for meshing, you may get lower bandwidth (2.4 GHz) or reduced range (5 GHz).
+
 ### uplink over LTE modem
 
 Many LTE USB sticks work as a so called USB CDC Net device. They emulate a standard ethernet device without any need for further configuration.

--- a/locations/w38b.yml
+++ b/locations/w38b.yml
@@ -172,14 +172,19 @@ networks:
       w38b-nas: 4 # 10.31.212.116
 
   # UPLK - 10.31.212.64/27 as /32
-  # - vid: 50
-  #   role: uplink
-  #
-  # - role: tunnel
-  #   ifname: ts_wg0
-  #   mtu: 1280
-  #   prefix: 10.31.212.64/32
-  #   wireguard_port: 51820
+  # Wireless uplink
+  - vid: 50
+    role: wireless_uplink
+    wireless_ssid: "Simulacron-1"
+    wireless_encryption: psk2
+    wireless_key: "file:/root/wireless_uplink_key"
+    radio: 11g_standard
+
+  - role: tunnel
+    ifname: ts_wg0
+    mtu: 1280
+    prefix: 10.31.212.64/32
+    wireguard_port: 51820
 
   # MGMT
   - vid: 434

--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -100,6 +100,21 @@ config device
   {% endif %}
 
 {% endfor %}
+{% for network in networks | selectattr('role', 'equalto', 'wireless_uplink') %}
+  {% set wd = wireless_devices | selectattr('name', 'equalto', network['radio']) | list | first %}
+config interface '{{ libnetwork.getUciIfname(network) }}'
+  option device '{{ wd['ifname_hint'] }}-sta'
+  {% if network.get('uplink_ipv4') %}
+  option proto 'static'
+  option ipaddr '{{ network['uplink_ipv4'] }}'
+    {% if network.get('uplink_gateway') %}
+  option gateway '{{ network['uplink_gateway'] }}'
+    {% endif %}
+  {% else %}
+  option proto 'none'
+  {% endif %}
+
+{% endfor %}
 {% for i in mac_override|default({}) %}
 config device '{{ i }}_dev'
 	option name '{{ i }}'

--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -39,7 +39,11 @@ config wifi-device '{{ wd_id }}'
   {% else %}
         option htmode 'VHT{{ bandwidth }}'
   {% endif %}
+  {# Skip channel setting for radios with wireless_uplink - station mode uses AP's channel #}
+  {% set has_wireless_uplink = networks | selectattr('role', 'equalto', 'wireless_uplink') | selectattr('radio', 'equalto', wd['name']) | list | length > 0 %}
+  {% if not has_wireless_uplink %}
 	option channel '{{ channel }}'
+  {% endif %}
   {% if txpower %}
 	option txpower '{{ txpower }}'
   {% elif 'antenna_gain' in wd %}
@@ -141,4 +145,35 @@ config wifi-iface '{{ wd_id }}_if{{ loop.index0 }}'
     {% endif %}
     {% endif %}
   {% endfor %}
+
+  {# Wireless uplink: station interface for connecting to external AP as uplink #}
+  {% set wireless_uplinks = networks | selectattr('role', 'equalto', 'wireless_uplink') | selectattr('radio', 'equalto', wd['name']) | list %}
+  {% if wireless_uplinks %}
+  {% set wireless_uplink = wireless_uplinks[0] %}
+config wifi-iface '{{ wd_id }}_sta'
+  option device '{{ wd_id }}'
+  option ifname '{{ wd['ifname_hint'] }}-sta'
+  option mode 'sta'
+  option ssid '{{ wireless_uplink['wireless_ssid'] }}'
+  {% if wireless_uplink.get('wireless_hidden') %}
+  option hidden '{{ wireless_uplink['wireless_hidden']|int }}'
+  {% endif %}
+  {# wireless_encryption/wireless_key: WPA2/WPA3 settings, defaults to open if not specified #}
+  {% if 'wireless_encryption' in wireless_uplink %}
+    {% if wireless_uplink['wireless_encryption'] == 'none' %}
+      {% if 'wireless_key' in wireless_uplink %}
+        {{ raise('wireless_key must not be set when wireless_encryption is "none"') }}
+      {% endif %}
+      option encryption 'none'
+    {% else %}
+      {% if 'wireless_key' not in wireless_uplink %}
+        {{ raise('wireless_key is required when wireless_encryption is set') }}
+      {% endif %}
+      option encryption '{{ wireless_uplink['wireless_encryption'] }}'
+      option key '{{ wireless_uplink['wireless_key'] }}'
+    {% endif %}
+  {% else %}
+    option encryption 'none'
+  {% endif %}
+  {% endif %}
 {% endfor %}

--- a/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
@@ -27,7 +27,7 @@ config domain '{{ host | replace('-', '_') }}_olsr'
   {% endfor %}
 {% endfor %}
 
-{% for network in networks | rejectattr('role', 'in', ['uplink', 'mesh', 'tunnel', 'ext']) %}
+{% for network in networks | rejectattr('role', 'in', ['uplink', 'wireless_uplink', 'mesh', 'tunnel', 'ext']) %}
     {% set name = network['name'] if 'name' in network else network['role'] %}
 
 config dhcp 'dhcp_{{ name }}'

--- a/roles/cfg_openwrt/templates/corerouter/config/olsrd.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/olsrd.j2
@@ -64,7 +64,7 @@ config Interface
   {% endfor %}
 
 {% endfor %}
-{% for network in networks | rejectattr('role', 'in', ['uplink','ext']) | selectattr('prefix') %}
+{% for network in networks | rejectattr('role', 'in', ['uplink','wireless_uplink','ext']) | selectattr('prefix') %}
   {% if network['prefix'] | ansible.utils.ipaddr('prefix') < 32 %}
 
 # Network: {{ network['name'] if 'name' in network else network['role'] }}

--- a/roles/cfg_openwrt/templates/corerouter/config/tunspace.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/tunspace.j2
@@ -1,26 +1,39 @@
 #jinja2: trim_blocks: True, lstrip_blocks: True
 {% import 'libraries/network.j2' as libnetwork with context %}
 
-{% for uplink in networks | selectattr('role', 'equalto', 'uplink') %}
-  {% set name = uplink['name'] if 'name' in uplink else 'uplink' %}
-  {% set mode = uplink['uplink_mode'] if 'uplink_mode' in uplink else 'bridge' %}
-  {% set ifname = libnetwork.getIfname(uplink) %}
+{% set all_uplinks = networks | selectattr('role', 'in', ['wireless_uplink', 'uplink']) | list %}
+{% for uplink in all_uplinks %}
+  {% if uplink['role'] == 'wireless_uplink' %}
+    {% set wd = wireless_devices | selectattr('name', 'equalto', uplink['radio']) | list | first %}
+    {% set uplink_netns = uplink['name']|default('wireless_uplink') %}
+    {% set uplink_ifname = wd['ifname_hint'] + '-sta' %}
+    {% set uplink_mode = 'passthru' %}
+    {% set uplink_mac = libnetwork.generateDeterministicMAC(inventory_hostname ~ "-tunspace-wlan") %}
+  {% else %}
+    {% set uplink_netns = uplink['name'] if 'name' in uplink else 'uplink' %}
+    {% set uplink_ifname = libnetwork.getIfname(uplink) %}
+    {% set uplink_mode = uplink['uplink_mode'] if 'uplink_mode' in uplink else 'bridge' %}
+    {% set uplink_mac = libnetwork.generateDeterministicMAC(inventory_hostname ~ "-tunspace") %}
+  {% endif %}
+  {% set uplink_ipv4 = uplink.get('uplink_ipv4', '') %}
+  {% set uplink_gateway = uplink.get('uplink_gateway', '') %}
 
 config tunspace "tunspace"
   # Namespace where the uplink will live.
-  option uplink_netns "{{ name }}"
-  # Existing interface that we'll use as the uplink.
-  option uplink_ifname "{{ ifname }}"
+  option uplink_netns "{{ uplink_netns }}"
+  # Existing interface (or wireless interface for wireless_uplink) used as the uplink.
+  option uplink_ifname "{{ uplink_ifname }}"
   # How the uplink in the namespace is constructed.
   # - bridge: creates a macvlan child in bridge mode, useful for creating multiple uplinks from the same original uplink interface.
+  # - passthru: macvlan shares parent MAC, required for wireless uplinks (DHCP works with single lease).
   # - direct: moves the original uplink interface into the namespace directly, useful for wonky cheap USB sticks with broken drivers.
-  option uplink_mode "{{ mode }}"
+  option uplink_mode "{{ uplink_mode }}"
   # Our own static uplink IPv4 address in CIDR format. Leave empty to use DHCP.
-  option uplink_ipv4 "{{ uplink['uplink_ipv4']|default('') }}"
+  option uplink_ipv4 "{{ uplink_ipv4 }}"
   # IPv4 address of the gateway. Required in combination with uplink_ipv4, ignored when using DHCP.
-  option uplink_gateway "{{ uplink['uplink_gateway']|default('') }}"
+  option uplink_gateway "{{ uplink_gateway }}"
   # Define deterministic mac address
-  option uplink_mac "{{- libnetwork.generateDeterministicMAC(inventory_hostname ~ "-tunspace") -}}"
+  option uplink_mac "{{ uplink_mac }}"
   # Maintenance consists of checking the uplink, refreshing the DHCP lease, checking the tunnel endpoints, and switching endpoints if neccessary.
   option maintenance_interval 60
   # Enables detailed output of Tunspace's operations. If disabled, only tunnel endpoint changes are reported.


### PR DESCRIPTION
This adds the option to specify a wireless network as an uplink interface. The corerouter will connect to the specified network and use tunspace to create a tunnel to one of our gateways. Channel settings for the radio of the wireless uplink will not be set anymore, therefore the channel is subject to change and the router will most likely not be able to mesh on that radio with other routers using the default channel.

This PR requires 

- [x] https://github.com/freifunk-berlin/falter-packages/pull/520 to be merged