### PR TITLE
feat: wireguard-access via corerouters

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -295,6 +295,105 @@ An optional configuration parameter can be added to any non-tunnel interface to 
 
 **WARNING:** This is made ineffective if [flow offloading](#flow-offloading) is enabled.
 
+### wireguard access vpn
+
+The core router can act as a WireGuard server, allowing remote clients to connect to specific VLANs/networks. Each peer is assigned to a network via the `vid` field, and their IP address is derived from the network's assignments.
+
+#### Requirements
+
+1. The network must have `assignments` defined (DHCP network with static assignments)
+2. Add a WireGuard peer assignment to the network's assignments
+3. Configure the `wireguard_access` section with peer definitions
+
+#### Configuration
+
+```yml
+wireguard_access:
+  port: 51820                           # WireGuard listen port (optional, default: 51820)
+  private_key_file: /root/wireguard.key  # Path to private key file (optional, default: /etc/wireguard/access.key)
+  peers:
+    - assignment: <name>               # Required: must match a key in the network's assignments
+      description: "<description>"      # Optional: for documentation
+      vid: <vid>                       # Required: VLAN ID of the network to assign peer to
+      public_key: "<key>"               # Required: WireGuard public key of the peer (add # gitleaks:allow comment)
+      persistent_keepalive: 25          # Optional: seconds between keepalive packets
+      preshared_key: "<key>"            # Optional: extra security key (add # gitleaks:allow comment if used)
+```
+
+**Note:** When adding actual public keys, append `# gitleaks:allow` to the line to prevent false-positive secrets scanning in the repository.
+
+#### Example
+
+In the `networks` section, add the WireGuard peer to assignments:
+
+```yml
+networks:
+  # Network with DHCP and assignments
+  - vid: 40
+    role: dhcp
+    name: dhcp
+    prefix: 10.0.0.0/24
+    ipv6_subprefix: 0
+    assignments:
+      example-core: 1         # 10.0.0.1
+      example-laptop-1: 10    # 10.0.0.10 - WireGuard peer
+```
+
+Then configure the `wireguard_access` section:
+
+```yml
+wireguard_access:
+  port: 51820
+  private_key_file: /root/wireguard.key
+  peers:
+    - assignment: example-laptop-1
+      description: "laptop home network"
+      vid: 40
+      public_key: "YOUR_PEER_PUBLIC_KEY"
+      persistent_keepalive: 25
+```
+
+#### Network Behavior
+
+- Each peer gets its own WireGuard interface (e.g., `wg_example-laptop-1`)
+- The interface is placed in the same firewall zone as the network it belongs to
+- If the network has `inbound_filtering: true`, the WireGuard peer inherits that behavior
+- This means the peer behaves exactly as if connected via WiFi/LAN to that VLAN
+
+#### Multiple Peers on Same VLAN
+
+Simply add more assignments and peers:
+
+```yml
+networks:
+  - vid: 40
+    name: dhcp
+    assignments:
+      example-laptop-1: 10    # 10.0.0.10
+      example-laptop-2: 11    # 10.0.0.11
+
+wireguard_access:
+  peers:
+    - assignment: example-laptop-1
+      vid: 40
+      public_key: "..."
+    - assignment: example-laptop-2
+      vid: 40
+      public_key: "..."
+```
+
+#### Gateway Deployment
+
+When enabling wireguard_access for the first time on a location, the **gateways must be deployed first** to receive the new firewall rules that allow incoming WireGuard connections from the mesh network to the core router. Deploy gateways before deploying the core router with wireguard_access configured.
+
+#### Validation
+
+The following errors are raised if configuration is invalid:
+- Peer missing required field: `assignment`, `vid`, or `public_key`
+- Peer references unknown `vid`
+- Network is missing required fields: `ipv6_subprefix`, `prefix`, or `assignments`
+- Peer assignment not found in network's assignments
+
 ### ssh-keys
 
 By default the ssh-keys within `all/ssh-keys.yml` will be installed on all hosts. To add additional ssh keys use this format:

--- a/roles/cfg_openwrt/tasks/conditional_packages.yml
+++ b/roles/cfg_openwrt/tasks/conditional_packages.yml
@@ -33,6 +33,13 @@
     - networks | selectattr('role', 'defined') | selectattr('role','equalto','tunnel') | count > 0
     - role == 'corerouter'
 
+- name: "Add wireguard if wireguard_access configured"
+  set_fact:
+    packages: "{{ packages + ['kmod-wireguard', 'wireguard-tools'] }}"
+  when:
+    - wireguard_access is defined
+    - role == 'corerouter'
+
 - name: "Add zram-swap on low mem and big flash"
   set_fact:
     packages: "{{ packages + ['zram-swap'] }}"

--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -116,3 +116,53 @@ config interface '{{ q['name'] }}'
 
   {% endfor %}
 {% endif %}
+{% if wireguard_access is defined and role == 'corerouter' and ipv6_prefix is defined %}
+{% for peer in wireguard_access['peers'] | default([]) %}
+{% if 'vid' not in peer %}
+{{ raise('wireguard_access peer is missing required field: vid') }}
+{% endif %}
+{% if 'assignment' not in peer %}
+{{ raise('wireguard_access peer is missing required field: assignment') }}
+{% endif %}
+{% if 'public_key' not in peer %}
+{{ raise('wireguard_access peer is missing required field: public_key') }}
+{% endif %}
+{% set network = networks | selectattr('vid', 'equalto', peer['vid']) | first %}
+{% if network is undefined %}
+{{ raise('wireguard_access peer references unknown vid: ' ~ peer['vid']) }}
+{% endif %}
+{% if 'ipv6_subprefix' not in network %}
+{{ raise('wireguard_access peer references network without ipv6_subprefix: vid ' ~ peer['vid']) }}
+{% endif %}
+{% if 'prefix' not in network %}
+{{ raise('wireguard_access peer references network without prefix: vid ' ~ peer['vid']) }}
+{% endif %}
+{% if 'assignments' not in network or peer['assignment'] not in network['assignments'] %}
+{{ raise('wireguard_access peer assignment "' ~ peer['assignment'] ~ '" not found in network assignments for vid ' ~ peer['vid']) }}
+{% endif %}
+{% set peer_ip = network['prefix'] | ansible.utils.ipaddr(network['assignments'][peer['assignment']]) | ansible.utils.ipaddr('address') %}
+{% set peer_ip_v6 = (ipv6_prefix | ansible.utils.ipsubnet('64', network['ipv6_subprefix']) | ansible.utils.ipaddr(network['assignments'][peer['assignment']]) | ansible.utils.ipaddr('address')) %}
+{% set wg_ifname = 'wg_' ~ peer['assignment'] %}
+{% set wg_ipv6_subnet = ipv6_prefix | ansible.utils.ipsubnet('64', network['ipv6_subprefix']) %}
+{% set wg_prefix = network['prefix'] %}
+
+config interface '{{ wg_ifname }}'
+  option proto 'wireguard'
+  option private_key 'file:{{ wireguard_access['private_key_file'] | default('/etc/wireguard/access.key') }}'
+  option listen_port '{{ wireguard_access['port'] | default(51820) }}'
+  list addresses '{{ peer_ip_v6 }}/64'
+  list addresses '{{ peer_ip }}'
+
+config wireguard_{{ wg_ifname }}
+  option public_key '{{ peer['public_key'] }}'
+{% if 'preshared_key' in peer %}
+  option preshared_key '{{ peer['preshared_key'] }}'
+{% endif %}
+  list allowed_ips '{{ peer_ip_v6 }}/128'
+  list allowed_ips '{{ peer_ip }}/32'
+{% if 'persistent_keepalive' in peer %}
+  option persistent_keepalive '{{ peer['persistent_keepalive'] }}'
+{% endif %}
+
+{% endfor %}
+{% endif %}

--- a/roles/cfg_openwrt/templates/corerouter/config/firewall.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/firewall.j2
@@ -23,7 +23,6 @@ config zone 'zone_freifunk'
 	{% for name in zone_freifunk_networks %}
 	list network '{{ name }}'
 	{% endfor %}
-	list device 'wg_+'
 	list device 'ts_+'
 
 {% for i in l3_networks | selectattr('inbound_filtering') %}
@@ -32,6 +31,27 @@ config zone 'zone_{{ i['name'] }}'
         list network '{{ i['name'] }}'
 
 {% endfor %}
+{% if wireguard_access is defined %}
+{% set wg_vids = wireguard_access['peers'] | map(attribute='vid') | unique | list %}
+{% for vid in wg_vids %}
+{% set network = networks | selectattr('vid', 'equalto', vid) | first %}
+{% set peer = wireguard_access['peers'] | selectattr('vid', 'equalto', vid) | first %}
+{% set wg_ifname = 'wg_' ~ peer['assignment'] %}
+{% if network.inbound_filtering | default(false) %}
+config zone 'zone_{{ network.name }}'
+        list device '{{ wg_ifname }}'
+{% else %}
+config zone 'zone_freifunk'
+        list device '{{ wg_ifname }}'
+{% endif %}
+{% endfor %}
+config rule
+        option name             'Allow WireGuard Access VPN'
+        option proto            udp
+        option dest_port        '{{ wireguard_access['port'] | default(51820) }}'
+        option target           ACCEPT
+
+{% endif %}
 config forwarding
 	option dest 'freifunk'
 	option src 'freifunk'

--- a/roles/cfg_openwrt/templates/gateway/config/firewall.j2
+++ b/roles/cfg_openwrt/templates/gateway/config/firewall.j2
@@ -252,9 +252,26 @@ config rule
 	option src_port		'{{ rule['src_port'] }}'
   {% endif %}
   {% if 'dst_port' in rule %}
-	option dest_port	'{{ rule['dst_port'] }}'
+ 	option dest_port	'{{ rule['dst_port'] }}'
   {% endif %}
-	option target		ACCEPT
+ 	option target		ACCEPT
+{% endfor %}
+
+# Allow WireGuard access VPN connections to corerouters
+{% for h in groups['role_corerouter'] | sort %}
+{% set h_vars = hostvars[h] %}
+{% if h_vars['wireguard_access'] is defined and h_vars['ipv6_prefix'] is defined %}
+{% set wg_port = h_vars['wireguard_access']['port'] | default(51820) %}
+config rule
+        option name             'Allow WireGuard access VPN {{ h }}'
+        option src              uplink
+        option dest             freifunk
+        option dest_ip          '{{ h_vars['ipv6_prefix'] }}'
+        option proto            udp
+        option dest_port        '{{ wg_port }}'
+        option target           ACCEPT
+
+{% endif %}
 {% endfor %}
 
 # Allow essential forwarded IPv6 ICMP traffic


### PR DESCRIPTION
Add per-VLAN WireGuard access VPN to corerouters. Each peer is assigned to a specific VLAN/network via the 'vid' field, with IP addresses derived from the network's assignments. This provides access and behaves exactly as if connected via WiFi/LAN to that VLAN.

Key features:
- Per-VLAN WireGuard interfaces (e.g., wg_wexample-laptop-1)
- Zone placement based on network's inbound_filtering setting
- Gateway firewall rules allow incoming WG connections from mesh
- Validation errors for missing required fields
- Documentation with examples