### PR TITLE
all: switch imagebuilder back to official OpenWRT

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -2,8 +2,8 @@
 # default OpenWRT version to build from unless overridden
 openwrt_version: 25.12-SNAPSHOT
 
-# openwrt_mirror: https://downloads.openwrt.org
-openwrt_mirror: https://mirror.berlin.freifunk.net/downloads.openwrt.org
+openwrt_mirror: https://downloads.openwrt.org
+# openwrt_mirror: https://mirror.berlin.freifunk.net/downloads.openwrt.org
 openwrt_base: "{{ 'snapshots' if openwrt_version == 'snapshot' else 'releases/' ~ openwrt_version }}"
 
 imagebuilder_suffix: zst # Might get overridden for older openwrt versions


### PR DESCRIPTION
Building from our mirror does not work reliably. Switch back to the official OpenWRT mirror until this is fixed.