### PR TITLE
wuhli: change corerouter to fritzbox 4040

### DIFF
--- a/locations/wuhli.yml
+++ b/locations/wuhli.yml
@@ -11,7 +11,7 @@ community: berlin
 hosts:
   - hostname: wuhli-core
     role: corerouter
-    model: "tplink_tl-wdr4900-v1"
+    model: "avm_fritzbox-4040"
     wireless_profile: freifunk_default
 
   - hostname: wuhli-n-nf-5ghz


### PR DESCRIPTION
Looks like the core device broke. Exchange it with a new one.