### PR TITLE
bird: reduce Babel hello/update intervals on tunnel interfaces

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/bird.conf.j2
+++ b/roles/cfg_openwrt/templates/corerouter/bird.conf.j2
@@ -79,6 +79,8 @@ protocol babel {
 {% for nw in networks | selectattr('role', 'equalto', 'tunnel') %}
 	interface "{{ nw.get('ifname') }}" {
 		type wireless;
+		hello interval 1s;
+		update interval 5s;
 	};
 {% endfor %}
 }


### PR DESCRIPTION
Tunnel interfaces (ts_wg0 etc.) used Bird's defaults: 4s hello and 20s update interval. This meant initial route convergence after a tunnel comes up took up to ~25 seconds in the best case.

Set hello interval to 1s and update interval to 5s for tunnel interfaces. The overhead is negligible (~50 bytes/s per tunnel). type wireless is kept intentionally: its smoothed rxcost model tolerates brief packet loss during the WireGuard handshake (~15s) without immediately withdrawing routes, which matters when tunspace switches gateway servers.