### PR TITLE
templates: fix "Netlink: File exists" warnings by not re-exporting learned routes

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/bird.conf.j2
+++ b/roles/cfg_openwrt/templates/corerouter/bird.conf.j2
@@ -89,7 +89,7 @@ protocol kernel {
 	ipv6 sadr {
 		table v6_main;
 		import all;
-		export all;
+		export where source != RTS_INHERIT;
 	};
 	learn all; # Allow learning loopback route
 }

--- a/roles/cfg_openwrt/templates/gateway/bird.conf.j2
+++ b/roles/cfg_openwrt/templates/gateway/bird.conf.j2
@@ -22,7 +22,7 @@ protocol kernel kernel_v6_main {
 	ipv6 sadr {
 		table v6_main;
 		import all;
-		export all;
+		export where source != RTS_INHERIT;
 	};
 	learn all; # Allow learning loopback route
 }


### PR DESCRIPTION
The IPv6 SADR kernel protocol had 'learn all' + 'export all', causing routes learned from the kernel (RTS_INHERIT) to be written back to the kernel, which returns EEXIST. Fix by filtering out learned routes from the export.