### PR TITLE
model: mikrotik 750gr3, disable wireless

### DIFF
--- a/group_vars/model_mikrotik_routerboard_750gr3.yml
+++ b/group_vars/model_mikrotik_routerboard_750gr3.yml
@@ -2,6 +2,7 @@
 target: ramips/mt7621
 brand_nice: MikroTik
 model_nice: hEX
+wireless_profile: disable
 openwrt_version: 25.12-SNAPSHOT
 
 dsa_ports:


### PR DESCRIPTION
The 750gr3 routerboard (hex) does not support wireless capabilities. Therefore we can disable the wireless profile for this device.