### PR TITLE
ak36-gw: give unifi controller a second name

### DIFF
--- a/locations/ak36.yml
+++ b/locations/ak36.yml
@@ -73,6 +73,7 @@ mgmt:
     config: 22 # .150
     monitor: 23 # .151
     unifi: 29 # .157
+    unifi-controller: 29 # .157 two names for the unifi controller
     uisp: 30 # .158
 
 # Mesh Network: 10.31.130.160/27


### PR DESCRIPTION
If there is a local unifi controller, and the network overrides the unifi.ff hostname with their local one, then the backbone unifi controller will no longer be available.  Therefore a new extra name "unifi-controller".

In addition, if there is a local unifi controll and the unifi.ff hostname is not overridden locally, then the AP's will try to register with the backbone unifi controller.  This would be the reason for someone to override the unifi.ff hostname