### PR TITLE
mass-update: skip password check when SSH connection fails

### DIFF
--- a/mass-update.sh
+++ b/mass-update.sh
@@ -107,6 +107,11 @@ check_missing_root_password() {
 
 	# Get the password field of root, or handle if the root user is missing
 	password_field=$(run_ssh "$hostname" "awk -F: '\$1 == \"root\" { print \$2 }' /etc/shadow" 2>/dev/null)
+	local ssh_exit_code=$?
+
+	if [ $ssh_exit_code -ne 0 ]; then
+		return
+	fi
 
 	if [[ -z "$password_field" || "$password_field" =~ ^(\*|!|)?$ ]]; then
 		MISSING_PASSWORD_DEVICES+=("$hostname")


### PR DESCRIPTION
check_missing_root_password() was falsely reporting devices as missing a root password when the SSH connection itself failed due to a transient network error. Even though the device was just verified reachable, the subsequent SSH command in run_ssh can still fail briefly. Fix by checking the SSH exit code before evaluating the password field.