### PR TITLE
roles: fix wireless uplink side effects for APs

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -100,6 +100,7 @@ config device
   {% endif %}
 
 {% endfor %}
+{% if role == 'corerouter' %}
 {% for network in networks | selectattr('role', 'equalto', 'wireless_uplink') %}
   {% set wd = wireless_devices | selectattr('name', 'equalto', network['radio']) | list | first %}
 config interface '{{ libnetwork.getUciIfname(network) }}'
@@ -115,6 +116,7 @@ config interface '{{ libnetwork.getUciIfname(network) }}'
   {% endif %}
 
 {% endfor %}
+{% endif %}
 {% for i in mac_override|default({}) %}
 config device '{{ i }}_dev'
 	option name '{{ i }}'

--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -39,9 +39,9 @@ config wifi-device '{{ wd_id }}'
   {% else %}
         option htmode 'VHT{{ bandwidth }}'
   {% endif %}
-  {# Skip channel setting for radios with wireless_uplink - station mode uses AP's channel #}
+  {# Skip channel setting for corerouter radios with wireless_uplink - station mode uses AP's channel #}
   {% set has_wireless_uplink = networks | selectattr('role', 'equalto', 'wireless_uplink') | selectattr('radio', 'equalto', wd['name']) | list | length > 0 %}
-  {% if not has_wireless_uplink %}
+  {% if not (role == 'corerouter' and has_wireless_uplink) %}
 	option channel '{{ channel }}'
   {% endif %}
   {% if txpower %}
@@ -146,7 +146,8 @@ config wifi-iface '{{ wd_id }}_if{{ loop.index0 }}'
     {% endif %}
   {% endfor %}
 
-  {# Wireless uplink: station interface for connecting to external AP as uplink #}
+  {# Wireless uplink: station interface for connecting to external AP as uplink (corerouter only) #}
+  {% if role == 'corerouter' %}
   {% set wireless_uplinks = networks | selectattr('role', 'equalto', 'wireless_uplink') | selectattr('radio', 'equalto', wd['name']) | list %}
   {% if wireless_uplinks %}
   {% set wireless_uplink = wireless_uplinks[0] %}
@@ -174,6 +175,7 @@ config wifi-iface '{{ wd_id }}_sta'
     {% endif %}
   {% else %}
     option encryption 'none'
+  {% endif %}
   {% endif %}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
Without the conditions added by this commit the APs got the same wireless STA interface and also did not get the wireless channel for the radio set. This broke meshing for the AP due to using an invalid frequency. With the conditions in place we now ensure that we only do these changes for corerouters.