### PR TITLE
roles: fix wireless uplink conflicts with mesh

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -274,6 +274,7 @@ The wireless uplink works together with tunnel configurations. The wireless inte
 - Only usable on corerouter role
 - The specified radio must be available on the router model
 - Passwords use the `file:/path/to/file` pattern and are replaced on first boot
+- **Mesh networks on the same radio will not be configured.** On the core router, when a wireless uplink is configured on a radio, any mesh (802.11s) interfaces on that same radio will be skipped. This is because both the STA (wireless uplink) and the mesh interfaces would try to set the channel. Whoever succeeds first defines it, making the configuration unreliable.
 
 **Device Limitations:**
 Not all devices support running multiple APs, 802.11s mesh, and a STA (station) interface simultaneously on the same radio. To check if your device supports this configuration, run:

--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -84,7 +84,8 @@ config wifi-device '{{ wd_id }}'
       {% endif %}
     {% endif %}
 
-    {% if iface['mode'] == 'ap' or (iface['mode'] == 'mesh' and mesh_net) %}
+    {# On the core router with a wireless uplink, skip mesh on radios used for that uplink - both the STA and mesh would try to set the channel, whoever succeeds first defines it, making the configuration unreliable. This is documented in DEVELOPER.md. #}
+    {% if iface['mode'] == 'ap' or (iface['mode'] == 'mesh' and mesh_net and not (role == 'corerouter' and has_wireless_uplink)) %}
 config wifi-iface '{{ wd_id }}_if{{ loop.index0 }}'
 	option device '{{ wd_id }}'
     {% if 'network' in iface %}


### PR DESCRIPTION
On the core router, when a wireless uplink is configured on a radio, any mesh (802.11s) interfaces on that same radio will be skipped. This is because both the STA (wireless uplink) and the mesh interfaces would try to set the channel. Whoever succeeds first defines it, making the configuration unreliable.