### PR TITLE
workflows: remove stale branches

### DIFF
--- a/.github/workflows/remove-stale-branches.yml
+++ b/.github/workflows/remove-stale-branches.yml
@@ -1,0 +1,33 @@
+---
+name: Remove Stale Branches
+
+#
+# Documentation:
+# https://github.com/marketplace/actions/remove-stale-branches
+#
+
+on:
+  schedule:
+    - cron: "15 * * * *" # Switch to something more reasonable when removing dry-run mode
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  remove-stale-branches:
+    name: Remove Stale Branches
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+      pull-requests: read
+
+    steps:
+      - uses: fpicalausa/remove-stale-branches@v2.6.1
+        with:
+          dry-run: true
+          exempt-branches-regex: "^(main)$"
+          ignore-branches-with-open-prs: true
+          days-before-branch-stale: 180
+          days-before-branch-delete: 14


### PR DESCRIPTION
During the Community Day, we discussed our intention to delete stale branches. This pull request sets up a workflow to accomplish this, with the exception of the `main` branch and any branches that have an associated pull request. We are initially implementing this action in dry-run mode to allow us to review the output; once we are satisfied with the results, we will remove the dry-run flag.