### PR TITLE
Use stable OpenWRT version for 25.12

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -1,6 +1,6 @@
 ---
 # default OpenWRT version to build from unless overridden
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 openwrt_mirror: https://downloads.openwrt.org
 # openwrt_mirror: https://mirror.berlin.freifunk.net/downloads.openwrt.org

--- a/group_vars/model_avm_fritzbox_4040.yml
+++ b/group_vars/model_avm_fritzbox_4040.yml
@@ -2,7 +2,7 @@
 target: ipq40xx/generic
 brand_nice: AVM
 model_nice: FRITZ!Box 4040
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"

--- a/group_vars/model_avm_fritzbox_7530.yml
+++ b/group_vars/model_avm_fritzbox_7530.yml
@@ -2,7 +2,7 @@
 target: ipq40xx/generic
 brand_nice: AVM
 model_nice: FRITZ!Box 7530
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct -ltq-vdsl-vr11-app"

--- a/group_vars/model_bananapi_bpi_r64.yml
+++ b/group_vars/model_bananapi_bpi_r64.yml
@@ -2,7 +2,7 @@
 target: mediatek/mt7622
 brand_nice: Sinovoip
 model_nice: Banana Pi R64
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - wan

--- a/group_vars/model_comfast_cf_ew72.yml
+++ b/group_vars/model_comfast_cf_ew72.yml
@@ -3,7 +3,7 @@ target: ath79/generic
 brand_nice: COMFAST
 model_nice: CF-EW72
 version_nice: v1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 int_port: eth0
 

--- a/group_vars/model_cudy_ap3000_v1.yml
+++ b/group_vars/model_cudy_ap3000_v1.yml
@@ -3,7 +3,7 @@ target: mediatek/filogic
 brand_nice: Cudy
 model_nice: AP3000
 version_nice: v1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 int_port: eth0
 

--- a/group_vars/model_cudy_ap3000outdoor_v1.yml
+++ b/group_vars/model_cudy_ap3000outdoor_v1.yml
@@ -3,7 +3,7 @@ target: mediatek/filogic
 brand_nice: Cudy
 model_nice: AP3000 Outdoor
 version_nice: v1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 int_port: eth0
 

--- a/group_vars/model_cudy_tr3000_v1.yml
+++ b/group_vars/model_cudy_tr3000_v1.yml
@@ -3,7 +3,7 @@ target: "mediatek/filogic"
 brand_nice: Cudy
 model_nice: TR3000
 version_nice: v1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - eth0

--- a/group_vars/model_cudy_wr3000_v1.yml
+++ b/group_vars/model_cudy_wr3000_v1.yml
@@ -3,7 +3,7 @@ target: mediatek/filogic
 brand_nice: Cudy
 model_nice: WR3000
 version_nice: v1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 # wr3000 does not have enough flash for debug utilities like tmux or mosh-server
 model__packages__to_merge:

--- a/group_vars/model_cudy_wr3000e_v1.yml
+++ b/group_vars/model_cudy_wr3000e_v1.yml
@@ -4,7 +4,7 @@ brand_nice: Cudy
 model_nice: WR3000E
 version_nice: v1
 
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - wan

--- a/group_vars/model_cudy_wr3000h_v1.yml
+++ b/group_vars/model_cudy_wr3000h_v1.yml
@@ -3,7 +3,7 @@ target: mediatek/filogic
 brand_nice: Cudy
 model_nice: WR3000H
 version_nice: v1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - wan

--- a/group_vars/model_cudy_x6_v1.yml
+++ b/group_vars/model_cudy_x6_v1.yml
@@ -3,7 +3,7 @@ target: ramips/mt7621
 brand_nice: Cudy
 model_nice: X6
 version_nice: v1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - lan1

--- a/group_vars/model_dlink_covr_x1860_a1.yml
+++ b/group_vars/model_dlink_covr_x1860_a1.yml
@@ -6,7 +6,7 @@ target: ramips/mt7621
 brand_nice: D-Link
 model_nice: COVR-X1860
 version_nice: A1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - internet

--- a/group_vars/model_dlink_dap_x1860_a1.yml
+++ b/group_vars/model_dlink_dap_x1860_a1.yml
@@ -3,7 +3,7 @@ target: ramips/mt7621
 brand_nice: D-Link
 model_nice: DAP-X1860
 version_nice: A1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 int_port: lan
 

--- a/group_vars/model_genexis_pulse_ex400.yml
+++ b/group_vars/model_genexis_pulse_ex400.yml
@@ -2,7 +2,7 @@
 target: ramips/mt7621
 brand_nice: Genexis
 model_nice: Pulse EX400
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - lan

--- a/group_vars/model_glinet_gl_mt6000.yml
+++ b/group_vars/model_glinet_gl_mt6000.yml
@@ -2,7 +2,7 @@
 target: "mediatek/filogic"
 brand_nice: GL.iNet
 model_nice: GL-MT6000 (Flint 2)
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - lan1

--- a/group_vars/model_linksys_e8450_ubi.yml
+++ b/group_vars/model_linksys_e8450_ubi.yml
@@ -3,7 +3,7 @@ target: mediatek/mt7622
 brand_nice: Belkin
 model_nice: RT3200
 
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - wan

--- a/group_vars/model_mikrotik_routerboard_750gr3.yml
+++ b/group_vars/model_mikrotik_routerboard_750gr3.yml
@@ -3,7 +3,7 @@ target: ramips/mt7621
 brand_nice: MikroTik
 model_nice: hEX
 wireless_profile: disable
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - wan

--- a/group_vars/model_mikrotik_routerboard_wap_g_5hact2hnd.yml
+++ b/group_vars/model_mikrotik_routerboard_wap_g_5hact2hnd.yml
@@ -3,7 +3,7 @@ override_target: "mikrotik_routerboard-wap-g-5hact2hnd"
 target: ath79/mikrotik
 brand_nice: MikroTik
 model_nice: wAP AC
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_mikrotik_sxtsq_2_lite.yml
+++ b/group_vars/model_mikrotik_sxtsq_2_lite.yml
@@ -3,7 +3,7 @@ override_target: "mikrotik_routerboard-lhg-2nd"
 target: ath79/mikrotik
 brand_nice: MikroTik
 model_nice: SXTsq Lite2
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 int_port: eth0
 

--- a/group_vars/model_mikrotik_sxtsq_5_ac.yml
+++ b/group_vars/model_mikrotik_sxtsq_5_ac.yml
@@ -2,7 +2,7 @@
 target: ipq40xx/mikrotik
 brand_nice: MikroTik
 model_nice: SXTsq 5 ac
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"

--- a/group_vars/model_openwrt_one.yml
+++ b/group_vars/model_openwrt_one.yml
@@ -2,7 +2,7 @@
 target: mediatek/filogic
 brand_nice: OpenWrt
 model_nice: One
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - eth0

--- a/group_vars/model_siemens_ws_ap3610.yml
+++ b/group_vars/model_siemens_ws_ap3610.yml
@@ -2,7 +2,7 @@
 target: ath79/generic
 brand_nice: Siemens
 model_nice: WS-AP3610
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 int_port: eth0
 

--- a/group_vars/model_totolink_a7000r.yml
+++ b/group_vars/model_totolink_a7000r.yml
@@ -2,7 +2,7 @@
 target: ramips/mt7621
 brand_nice: TOTOLINK
 model_nice: A7000R
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - wan

--- a/group_vars/model_tplink_archer_a7_v5.yml
+++ b/group_vars/model_tplink_archer_a7_v5.yml
@@ -3,7 +3,7 @@ target: ath79/generic
 brand_nice: TP-Link
 model_nice: Archer A7
 version_nice: v5
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_tplink_archer_c5_v1.yml
+++ b/group_vars/model_tplink_archer_c5_v1.yml
@@ -3,7 +3,7 @@ target: ath79/generic
 brand_nice: TP-Link
 model_nice: Archer C5
 version_nice: v1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_tplink_archer_c6_v2.yml
+++ b/group_vars/model_tplink_archer_c6_v2.yml
@@ -3,7 +3,7 @@ target: ath79/generic
 brand_nice: TP-Link
 model_nice: Archer C6
 version_nice: v2
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 low_flash: true
 

--- a/group_vars/model_tplink_archer_c7_v5.yml
+++ b/group_vars/model_tplink_archer_c7_v5.yml
@@ -3,7 +3,7 @@ target: ath79/generic
 brand_nice: TP-Link
 model_nice: Archer C7
 version_nice: v5
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_tplink_eap225_outdoor_v1.yml
+++ b/group_vars/model_tplink_eap225_outdoor_v1.yml
@@ -3,7 +3,7 @@ target: ath79/generic
 brand_nice: TP-Link
 model_nice: EAP225
 version_nice: v1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 int_port: eth0
 

--- a/group_vars/model_tplink_eap225_outdoor_v3.yml
+++ b/group_vars/model_tplink_eap225_outdoor_v3.yml
@@ -3,7 +3,7 @@ target: ath79/generic
 brand_nice: TP-Link
 model_nice: EAP225
 version_nice: v3
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 int_port: eth0
 

--- a/group_vars/model_tplink_tl_wdr4900_v1.yml
+++ b/group_vars/model_tplink_tl_wdr4900_v1.yml
@@ -3,7 +3,7 @@ target: mpc85xx/p1010
 brand_nice: TP-Link
 model_nice: WDR4900
 version_nice: v1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - wan

--- a/group_vars/model_ubnt_edgerouter_x_sfp.yml
+++ b/group_vars/model_ubnt_edgerouter_x_sfp.yml
@@ -4,7 +4,7 @@ target: ramips/mt7621
 brand_nice: Ubiquiti
 model_nice: EdgeRouter X SFP
 
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 model__packages__to_merge:
   - "kmod-gpio-pca953x" # GPIO expander driver

--- a/group_vars/model_ubnt_unifi_6_lite.yml
+++ b/group_vars/model_ubnt_unifi_6_lite.yml
@@ -2,7 +2,7 @@
 target: ramips/mt7621
 brand_nice: Ubiquiti
 model_nice: UniFi 6 Lite
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - lan

--- a/group_vars/model_ubnt_unifiac_mesh.yml
+++ b/group_vars/model_ubnt_unifiac_mesh.yml
@@ -2,7 +2,7 @@
 target: ath79/generic
 brand_nice: Ubiquiti
 model_nice: UniFi AC Mesh
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_ubnt_usw_flex.yml
+++ b/group_vars/model_ubnt_usw_flex.yml
@@ -10,7 +10,7 @@
 target: ramips/mt7621
 brand_nice: Ubiquiti
 model_nice: USW-Flex
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - lan1

--- a/group_vars/model_x86_64.yml
+++ b/group_vars/model_x86_64.yml
@@ -3,7 +3,7 @@ target: x86/64
 override_target: generic
 image_search_pattern: "*-ext4-combined.img*"
 model_nice: x86/64 Generic
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 int_port: eth0
 

--- a/group_vars/model_xiaomi_aiot_ac2350.yml
+++ b/group_vars/model_xiaomi_aiot_ac2350.yml
@@ -3,7 +3,7 @@ target: ath79/generic
 brand_nice: Xiaomi
 model_nice: AIoT AC2350
 version_nice: v1
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - eth0.1 # LAN 1-3

--- a/group_vars/model_zyxel_nbg6617.yml
+++ b/group_vars/model_zyxel_nbg6617.yml
@@ -2,7 +2,7 @@
 target: ipq40xx/generic
 brand_nice: ZyXEL
 model_nice: NBG6617
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"

--- a/group_vars/model_zyxel_nwa50ax.yml
+++ b/group_vars/model_zyxel_nwa50ax.yml
@@ -2,7 +2,7 @@
 target: ramips/mt7621
 brand_nice: ZyXEL
 model_nice: NWA50AX
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - lan

--- a/group_vars/model_zyxel_nwa55axe.yml
+++ b/group_vars/model_zyxel_nwa55axe.yml
@@ -2,7 +2,7 @@
 target: ramips/mt7621
 brand_nice: ZyXEL
 model_nice: NWA55AXE
-openwrt_version: 25.12-SNAPSHOT
+openwrt_version: 25.12.4
 
 dsa_ports:
   - lan

--- a/group_vars/version_25_12_4.yml
+++ b/group_vars/version_25_12_4.yml
@@ -1,0 +1,4 @@
+---
+feed_version: 1.6.0-snapshot
+feed: "https://firmware.berlin.freifunk.net/feed/{{ feed_version }}/packages/__INSTR_SET__/falter/packages.adb"
+uses_apk: true


### PR DESCRIPTION
As discussed on the last communityday, I moved the default version as well as all `25.12-SNAPSHOT` devices to stable. We can move over the devices still targeting older versions when we move them up a major release.