### PR TITLE
Images automation

### DIFF
--- a/.github/workflows/imagerun.yml
+++ b/.github/workflows/imagerun.yml
@@ -1,0 +1,90 @@
+---
+name: Image Run
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    types:
+      - "labeled"
+
+permissions:
+  contents: write # required for artifacts
+  actions: read
+
+jobs:
+  build:
+    name: Ansible Image Run
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'build_image' }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: pip3 install -r requirements.txt --upgrade pip
+
+      - name: Determine branch name
+        run: |
+          BRANCH="${GITHUB_BASE_REF#refs/heads/}"
+          echo "Building for $BRANCH"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+
+      - name: Determine changed locations
+        run: |
+          CHANGED_HOSTS=$(git diff --diff-filter=d --name-only "origin/$BRANCH" \
+            | grep 'host_vars/' \
+            | sed 's/host_vars\/\(.*\)\/.*/\1/' \
+            | sort \
+            | uniq \
+            | sed -z 's/\n/,/g;s/,$//')
+          echo "Building for $CHANGED_HOSTS"
+          echo "CHANGED_HOSTS=$CHANGED_HOSTS" >> "$GITHUB_ENV"
+
+          CHANGED_LOCATIONS=$(git diff --diff-filter=d --name-only "origin/$BRANCH" \
+            | grep 'group_vars/location_' \
+            | sed 's/group_vars\/\(.*\)\/.*/\1/' \
+            | sort \
+            | uniq \
+            | sed -z 's/\n/,/g;s/,$//')
+          CHANGED_SINGE_FILE_LOCATIONS=$(git diff --diff-filter=d --name-only "origin/$BRANCH" \
+            | grep 'locations/' \
+            | sed 's/locations\/\(.*\)\.yml/location_\1/' \
+            | sed -z 's/-/_/g;s/\n/,/g;s/,$//')
+          CHANGED_LOCATIONS=${CHANGED_LOCATIONS:+$CHANGED_LOCATIONS,}$CHANGED_SINGE_FILE_LOCATIONS
+
+          CHANGED_OTHER=$(git diff --diff-filter=d --name-only "origin/$BRANCH" \
+            | grep -xP '(inventory|roles)/.+' \
+            | sed -z 's/\n/,/g;s/,$//')
+          if [ -z "${CHANGED_LOCATIONS}" ] && [ -n "${CHANGED_OTHER}" ]; then
+            CHANGED_LOCATIONS="sama-core,sama-nord-5ghz,l105-gw"
+          fi
+          echo "Building for $CHANGED_LOCATIONS"
+          echo "CHANGED_LOCATIONS=$CHANGED_LOCATIONS" >> "$GITHUB_ENV"
+
+      - name: Build changed locations
+        run: |
+          if [ -n "${CHANGED_HOSTS}" ] || [ -n "${CHANGED_LOCATIONS}" ] ; then
+            ansible-playbook play.yml --limit "${CHANGED_HOSTS:+$CHANGED_HOSTS,}$CHANGED_LOCATIONS" --tags image
+          fi
+          mkdir -p ./tmp/images
+
+      - name: Create tar from configs folder
+        run: |
+          # create a tar containing the configs, as files with colons might be created which are rejected by upload-artifact
+          # upload-artifact rejects all files that might cause issues with file systems that do not support all characters
+          tar -cvf ./tmp/images.tar ./tmp/images/
+
+      - name: Store build output
+        uses: actions/upload-artifact@v5
+        with:
+          name: ansibleimages
+          path: |
+            ./tmp/images.tar

--- a/.github/workflows/imagerun.yml
+++ b/.github/workflows/imagerun.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: write # required for artifacts
   actions: read
+  pull-requests: write # required for Commenting
 
 jobs:
   build:
@@ -83,8 +84,17 @@ jobs:
           tar -cvf ./tmp/images.tar ./tmp/images/
 
       - name: Store build output
+        id: artifact-upload-step
         uses: actions/upload-artifact@v5
         with:
           name: ansibleimages
           path: |
             ./tmp/images.tar
+
+      - name: Comment link to artifacts
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            Hey :wave:
+            I am building images because you added the label `build_image`.
+            You can find the output [here](${{ steps.artifact-upload-step.outputs.artifact-url }}). If you need new images just add the label again.

--- a/.github/workflows/imagerun.yml
+++ b/.github/workflows/imagerun.yml
@@ -1,6 +1,11 @@
 ---
 name: Image Run
 
+# This workflow generates images of changed locations on user request.
+# Add the label 'build_image' to the PR to trigger a new image run.
+# This will run once. To trigger the workflow again you have to remove
+# the label first to add it again.
+
 on:
   pull_request:
     branches:
@@ -11,7 +16,7 @@ on:
 permissions:
   contents: write # required for artifacts
   actions: read
-  pull-requests: write # required for Commenting
+  pull-requests: write # required for commenting
 
 jobs:
   build:


### PR DESCRIPTION
Add a automation that gets triggered by the label `build_image`. This should help people to update routers even if they dont have a working local development setup for building images.

It will detect changed locations and just builds images for them. After that a download link will be posted.  If the user want to have new images after several changes the label would need to be removed and added again. This action is purely optional and wont run by default.

This fixes #1615 

[I tested this on my fork.](https://github.com/FFHener/bbb-configs/pull/28#issuecomment-4567491284)

EDIT: Im not sure if this should be an official way for building the images that we name in the Readme? For now i would leave it as an experimental feature and make sure its usefull the way it is