### PR TITLE
imageprofile: use owmsh package, remove falter-common

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -38,6 +38,7 @@ all_luci_base__packages__to_merge:
   - uhttpd-mod-ubus
 
 all_collectd__packages__to_merge:
+  - collectd-mod-cpu
   - collectd-mod-interface
   - collectd-mod-iwinfo
   - collectd-mod-load

--- a/group_vars/role_corerouter/imageprofile.yml
+++ b/group_vars/role_corerouter/imageprofile.yml
@@ -12,11 +12,7 @@ role_corerouter__packages__to_merge:
   - luci-app-olsr
   - luci-app-olsr-services
   - luci-mod-falter
-  - falter-common
-  - luci-app-falter-owm
-  - luci-app-falter-owm-ant
-  - luci-app-falter-owm-cmd
-  - luci-app-falter-owm-gui
+  - falter-berlin-owmsh
   - iptables-mod-ipopt
   - kmod-ipt-ipopt
 

--- a/group_vars/role_gateway/imageprofile.yml
+++ b/group_vars/role_gateway/imageprofile.yml
@@ -11,12 +11,8 @@ role_uplink_gw__packages__to_merge:
   - luci-app-olsr
   - luci-app-olsr-services
   - luci-mod-falter
-  - falter-common
+  - falter-berlin-owmsh
   - falter-berlin-gw
-  - luci-app-falter-owm
-  - luci-app-falter-owm-ant
-  - luci-app-falter-owm-cmd
-  - luci-app-falter-owm-gui
   - iptables-mod-ipopt
   - kmod-ipt-ipopt
   - bgpdisco


### PR DESCRIPTION
This removes a big chunk of useless dependencies: falter-common and the now deleted luci-all-falter-owm.

Instead use the standalone falter-berlin-owmsh package.

Not 100% sure if the removal of falter-common also removed some dependency which we might actually need, but I guess we'll see :)))