### PR TITLE
roles: add back freifunk_release file that was lost when removing fal…

### DIFF
--- a/roles/cfg_openwrt/templates/common/freifunk_release.j2
+++ b/roles/cfg_openwrt/templates/common/freifunk_release.j2
@@ -1,0 +1,4 @@
+FREIFUNK_DISTRIB_ID="Freifunk Falter"
+FREIFUNK_RELEASE='{{ feed_version }}'
+FREIFUNK_REVISION='{{ lookup("pipe", "git rev-parse --short HEAD") }}'
+FREIFUNK_VARIANT='standard'

--- a/roles/cfg_openwrt/templates/corerouter/freifunk_release.j2
+++ b/roles/cfg_openwrt/templates/corerouter/freifunk_release.j2
@@ -1,0 +1,1 @@
+../common/freifunk_release.j2

--- a/roles/cfg_openwrt/templates/gateway/freifunk_release.j2
+++ b/roles/cfg_openwrt/templates/gateway/freifunk_release.j2
@@ -1,0 +1,1 @@
+../common/freifunk_release.j2


### PR DESCRIPTION
…ter-common with the difference of using the bbbb-configs hash instead of the falter-packages hash

we need this so the nodes show up with the proper firmware version on the map, otherwise new builds show OpenWrt xx.xx.x instead of Freifunk Falter x.x.x-snapshot