### PR TITLE
imageprofile: replace owmsh with owm-ucode to add babel support

### DIFF
--- a/group_vars/role_corerouter/imageprofile.yml
+++ b/group_vars/role_corerouter/imageprofile.yml
@@ -12,7 +12,7 @@ role_corerouter__packages__to_merge:
   - luci-app-olsr
   - luci-app-olsr-services
   - luci-mod-falter
-  - falter-berlin-owmsh
+  - falter-berlin-owm-ucode
   - iptables-mod-ipopt
   - kmod-ipt-ipopt
 

--- a/group_vars/role_gateway/imageprofile.yml
+++ b/group_vars/role_gateway/imageprofile.yml
@@ -11,7 +11,7 @@ role_uplink_gw__packages__to_merge:
   - luci-app-olsr
   - luci-app-olsr-services
   - luci-mod-falter
-  - falter-berlin-owmsh
+  - falter-berlin-owm-ucode
   - falter-berlin-gw
   - iptables-mod-ipopt
   - kmod-ipt-ipopt


### PR DESCRIPTION
the owm-ucode rewrite adds support for babel links and comes with various improvements:
- first report to owm 5 minutes after boot, then 25 minutes afterwards and then every 30 minutes.
- only report the strongest link between two nodes to fix random poor links used in hopglass in 802.11s meshes