### PR TITLE
muggel: tweaks for the 5G uplink

### DIFF
--- a/locations/muggel.yml
+++ b/locations/muggel.yml
@@ -19,7 +19,14 @@ hosts:
   - hostname: muggel-core
     role: corerouter
     model: cudy_wr3000e-v1
+    openwrt_version: snapshot
+    flow_offload: hw
     wireless_profile: muggel
+    host__rclocal__to_merge:
+      - |
+        uci set network.vlan_40.ports='lan1:u lan2:u lan3:u lan4:u'
+        uci set network.vlan_50.ports='wan:u'
+        uci commit network; reload_config
 
 networks:
   - vid: 20
@@ -53,15 +60,15 @@ networks:
   # Uplink is a Zyxel NR7101 running OpenWrt
   # For 5G connection info, do:
   #   ssh root@muggel-core.ff ip netns exec uplink \
-  #     ssh -yy root@192.168.1.1 /usr/share/3ginfo-lite/3ginfo.sh \
-  #   | grep -E 'mode|signal|rx|tx'
+  #     ssh -yy root@192.168.1.1 /root/modeminfo.sh \
+  #   | grep -E 'Network|Signal|SINR|Band'
   - vid: 50
     untagged: true
     role: uplink
 
   - role: tunnel
     ifname: ts_wg0
-    mtu: 1280
+    mtu: 1420
     prefix: 10.31.220.10/32
     wireguard_port: 51820
 
@@ -93,3 +100,6 @@ location__wireless_profiles__to_merge:
         mesh_fwding: 0
         mesh_nolearn: 1
         ifname_hint: mesh
+
+location__channel_assignments_11a_standard__to_merge:
+  muggel-core: 36-40

--- a/locations/muggel.yml
+++ b/locations/muggel.yml
@@ -57,8 +57,21 @@ networks:
       muggel-core: 1
       muggel-uplink: 2
 
-  # Uplink is a Zyxel NR7101 running OpenWrt
-  # For 5G connection info, do:
+  # Uplink at 192.168.1.1 is a Zyxel NR7101 running vanilla OpenWrt
+  # For modem setup:
+  #   apk add kmod-usb-net kmod-usb-net-cdc-ether kmod-usb-net-cdc-mbim kmod-usb-net-cdc-ncm umbim wwan
+  #   uci batch "
+  #     network.wan=interface
+  #     network.wan.proto='mbim'
+  #     network.wan.device='/dev/cdc-wdm0'
+  #     network.wan.apn='internet'
+  #     network.wan.auth='none'
+  #     network.wan.pdptype='ipv4v6'"
+  # For modem status info:
+  #   modeminfo script from https://github.com/solomonricky/luci-app-modeminfo
+  #   apk add sms-tool
+  #   /root/modeminfo.sh | grep -E 'Network|Signal|SINR|Band'
+  # Modem status:
   #   ssh root@muggel-core.ff ip netns exec uplink \
   #     ssh -yy root@192.168.1.1 /root/modeminfo.sh \
   #   | grep -E 'Network|Signal|SINR|Band'

--- a/locations/muggel.yml
+++ b/locations/muggel.yml
@@ -27,6 +27,7 @@ hosts:
         uci set network.vlan_40.ports='lan1:u lan2:u lan3:u lan4:u'
         uci set network.vlan_50.ports='wan:u'
         uci commit network; reload_config
+      - cat /etc/crontabs/root | grep "ifdown wan" 2>/dev/null || echo "0 6 * * * ip netns exec uplink ssh -yy root@192.168.1.1 'ifdown wan ; sleep 5 ; ifup wan'" >> /etc/crontabs/root && /etc/init.d/cron restart
 
 networks:
   - vid: 20


### PR DESCRIPTION
Right now the modem loses connectivity every 24h and MBIM commands hang.

With an ifdown+ifup, it recovers after roughly 5 minutes and reconnects. If the connection is alive and healthy, the ifdown+ifup takes just a few seconds.

Let's see if this helps reliably.