### PR TITLE
version: fix 23.05.6 builds

### DIFF
--- a/group_vars/model_glinet_gl_mt3000.yml
+++ b/group_vars/model_glinet_gl_mt3000.yml
@@ -3,7 +3,7 @@ target: "mediatek/filogic"
 brand_nice: GL.iNet
 model_nice: GL-MT3000 (Beryl AX)
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 dsa_ports:
   - lan

--- a/group_vars/model_speedport_w_504v_typ_a.yml
+++ b/group_vars/model_speedport_w_504v_typ_a.yml
@@ -4,7 +4,7 @@ target: lantiq/xway
 brand_nice: Speedport
 model_nice: W 504V Typ A
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 switch_ports: 6
 switch_int_port: 0

--- a/group_vars/model_tplink_archer_c7_v4.yml
+++ b/group_vars/model_tplink_archer_c7_v4.yml
@@ -3,7 +3,7 @@ target: ath79/generic
 brand_nice: TP-Link
 model_nice: Archer C7
 version_nice: v4
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_tplink_cpe210_v3.yml
+++ b/group_vars/model_tplink_cpe210_v3.yml
@@ -4,7 +4,7 @@ brand_nice: TP-Link
 model_nice: CPE210
 version_nice: v3
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 int_port: eth0
 

--- a/group_vars/model_tplink_cpe510_v2.yml
+++ b/group_vars/model_tplink_cpe510_v2.yml
@@ -4,7 +4,7 @@ brand_nice: TP-Link
 model_nice: CPE510
 version_nice: v2
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 int_port: eth0
 

--- a/group_vars/model_tplink_cpe510_v3.yml
+++ b/group_vars/model_tplink_cpe510_v3.yml
@@ -4,7 +4,7 @@ brand_nice: TP-Link
 model_nice: CPE510
 version_nice: v3
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 int_port: eth0
 

--- a/group_vars/model_tplink_tl_wdr3600_v1.yml
+++ b/group_vars/model_tplink_tl_wdr3600_v1.yml
@@ -4,7 +4,7 @@ brand_nice: TP-Link
 model_nice: WDR3600
 version_nice: v1
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 low_flash: true
 

--- a/group_vars/model_tplink_tl_wdr4300_v1.yml
+++ b/group_vars/model_tplink_tl_wdr4300_v1.yml
@@ -4,7 +4,7 @@ brand_nice: TP-Link
 model_nice: WDR4300
 version_nice: v1
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 switch_ports: 6
 switch_int_port: 0

--- a/group_vars/model_tplink_tl_wr842n_v3.yml
+++ b/group_vars/model_tplink_tl_wr842n_v3.yml
@@ -4,7 +4,7 @@ brand_nice: TP-Link
 model_nice: TL-WR842N
 version_nice: v3
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 # eth0 is the switch, eth1 is WAN; just use WAN
 int_port: eth1

--- a/group_vars/model_ubnt_bullet_m2_ar7241.yml
+++ b/group_vars/model_ubnt_bullet_m2_ar7241.yml
@@ -5,7 +5,7 @@ brand_nice: Ubiquiti
 model_nice: Bullet M2
 version_nice: XM
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 int_port: eth0
 

--- a/group_vars/model_ubnt_bullet_m5_ar7241.yml
+++ b/group_vars/model_ubnt_bullet_m5_ar7241.yml
@@ -5,7 +5,7 @@ brand_nice: Ubiquiti
 model_nice: Bullet M5
 version_nice: XM
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 int_port: eth0
 

--- a/group_vars/model_ubnt_nanostation_ac_loco.yml
+++ b/group_vars/model_ubnt_nanostation_ac_loco.yml
@@ -3,7 +3,7 @@ target: ath79/generic
 brand_nice: Ubiquiti
 model_nice: Nanostation AC Loco
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_ubnt_nanostation_m2_xm.yml
+++ b/group_vars/model_ubnt_nanostation_m2_xm.yml
@@ -1,11 +1,12 @@
 ---
+# This device has been removed in OpenWrt 23.05, only XW is still supported
 override_target: "ubnt_nanostation-m"
 target: ath79/tiny
 brand_nice: Ubiquiti
 model_nice: Nanostation M2
 version_nice: XM
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 int_port: eth1
 

--- a/group_vars/model_ubnt_nanostation_m5_xm.yml
+++ b/group_vars/model_ubnt_nanostation_m5_xm.yml
@@ -1,11 +1,12 @@
 ---
+# This device has been removed in OpenWrt 23.05, only XW is still supported
 override_target: "ubnt_nanostation-m"
 target: ath79/tiny
 brand_nice: Ubiquiti
 model_nice: Nanostation M5
 version_nice: XM
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 int_port: eth1
 

--- a/group_vars/model_ubnt_powerbeam_m5_xw.yml
+++ b/group_vars/model_ubnt_powerbeam_m5_xw.yml
@@ -4,7 +4,7 @@ brand_nice: Ubiquiti
 model_nice: Powerbeam M5
 version_nice: XW
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 int_port: eth0
 

--- a/group_vars/model_ubnt_unifiac_lite.yml
+++ b/group_vars/model_ubnt_unifiac_lite.yml
@@ -3,7 +3,7 @@ target: ath79/generic
 brand_nice: Ubiquiti
 model_nice: UniFi AC Lite
 
-openwrt_version: 23.05-SNAPSHOT
+openwrt_version: 23.05.6
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/version_23_05_6.yml
+++ b/group_vars/version_23_05_6.yml
@@ -3,3 +3,7 @@ imagebuilder_suffix: xz
 openwrt_mirror: https://mirror.berlin.freifunk.net/downloads.openwrt.org
 feed_version: 1.4.0-snapshot
 uses_opkg: true
+
+bird__packages__to_merge:
+  - bird2-babelpatch
+  - bird2c

--- a/locations/fffw-rathaus.yml
+++ b/locations/fffw-rathaus.yml
@@ -12,7 +12,7 @@ hosts:
   - hostname: fffw-rathaus-core
     role: corerouter
     model: "linksys_e8450-ubi"
-    openwrt_version: 23.05-SNAPSHOT
+    openwrt_version: 23.05.6
     wireless_profile: freifunk_fw
 
 # IPv6 prefix from Berlin

--- a/locations/habersaath.yml
+++ b/locations/habersaath.yml
@@ -13,7 +13,7 @@ hosts:
   - hostname: habersaath-core
     role: corerouter
     model: "linksys_e8450-ubi"
-    openwrt_version: 23.05-SNAPSHOT
+    openwrt_version: 23.05.6
 
   - hostname: habersaath-w-nf-5ghz
     role: ap

--- a/locations/pktpls.yml
+++ b/locations/pktpls.yml
@@ -15,7 +15,7 @@ hosts:
 # feed: "file:///home/user/w/ff/falter-packages/out/main/x86_64/falter/packages.adb"
 # feed_key: "/home/user/w/ff/falter-packages/out/main/x86_64/public-key.pem"
 #
-# Custom OPKG feed: 24.10-SNAPSHOT, 23.05-SNAPSHOT
+# Custom OPKG feed: 24.10-SNAPSHOT, 23.05.6
 # feed: "src/gz openwrt_falter file:///home/user/w/ff/falter-packages/out/openwrt-24.10/x86_64/falter"
 # imagebuilder_disable_signature_check: true
 

--- a/locations/q217.yml
+++ b/locations/q217.yml
@@ -14,7 +14,7 @@ hosts:
     role: corerouter
     model: "linksys_e8450-ubi"
     wireless_profile: freifunk_default
-    openwrt_version: 23.05-SNAPSHOT
+    openwrt_version: 23.05.6
 
 snmp_devices:
   - hostname: q217-spitta

--- a/locations/rhxb.yml
+++ b/locations/rhxb.yml
@@ -12,7 +12,7 @@ hosts:
     role: corerouter
     model: "linksys_e8450-ubi"
     wireless_profile: freifunk_default
-    openwrt_version: 23.05-SNAPSHOT
+    openwrt_version: 23.05.6
     host__rclocal__to_merge:
       - |
         uci -q get system.@system[0].bbb_config_first_boot > /dev/null


### PR DESCRIPTION
- The 23.05 branch is EOL since September 2025 and its snapshot builds have been deleted from the download server. Instead we switch to the most recent proper release, as we do for all newer branches.
- Bird 3 has never been backported to 23.05 in OpenWrt's routing feed. So we keep our 23.05 builds on Bird 2 for now.