### PR TITLE
imagebuilder: fix eed_key typo blocking custom APK feed key installat…

### DIFF
--- a/roles/cfg_openwrt/tasks/imagebuilder.yml
+++ b/roles/cfg_openwrt/tasks/imagebuilder.yml
@@ -150,7 +150,7 @@
     src: "{{ feed_key }}"
     dest: "{{ configs_dir }}/etc/apk/keys/falter.custom.pem"
     mode: "preserve"
-  when: "uses_apk is defined and feed_version is defined and eed_key is defined"
+  when: "uses_apk is defined and feed_version is defined and feed_key is defined"
 
 - name: Override compat_version check to bbb-configs exclusive value 9.9
   lineinfile:


### PR DESCRIPTION
…ion into images

'Add custom APK feed key to image' checked `eed_key is defined` instead of `feed_key is defined`, so it never ran regardless of whether feed_key was set. The key still reached the imagebuilder's own keyring (a separate, correctly-spelled task), so builds succeeded, but the deployed image never got the key in /etc/apk/keys/ - any live apk operation against that custom feed on the router itself would fail signature verification. Found while reviewing the adblock-lean package/feed integration; feed_key is in live use by locations/pktpls.yml.